### PR TITLE
Add a brain-backed Wikidata queue for bot triage and publication

### DIFF
--- a/site/annotations/Algebraically_closed_field.json
+++ b/site/annotations/Algebraically_closed_field.json
@@ -1,0 +1,1002 @@
+{
+  "slug": "Algebraically_closed_field",
+  "wikipedia_title": "Algebraically closed field",
+  "display_title": "Algebraically closed field",
+  "schema_version": 3,
+  "annotation_style": "theorem_article",
+  "annotations": [
+    {
+      "kind": "definition",
+      "label": "Algebraically closed field",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "a field F is algebraically closed if every non-constant polynomial with coefficients in F has a root in F"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosed",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "Mathlib defines `IsAlgClosed` by polynomial splitting and proves the root formulation as `IsAlgClosed.exists_root`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Fundamental theorem formulation",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "a field is algebraically closed if the fundamental theorem of algebra holds for it"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed.exists_root",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has the root-existence property for algebraically closed fields, but not this phrasing as a separate fundamental-theorem equivalence for an arbitrary field.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Real numbers not algebraically closed",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "the field of real numbers is not algebraically closed because the polynomial"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsSemireal.not_isSumSq_neg_one",
+        "module": "Mathlib.Algebra.Ring.Semireal.Defs",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has semireal obstruction infrastructure implying negative one is not a sum of squares in ordered contexts, but I found no direct `¬ IsAlgClosed ℝ` declaration.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Complex numbers algebraically closed",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "the field of complex numbers is algebraically closed"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Complex.isAlgClosed",
+        "module": "Mathlib.Analysis.Complex.Polynomial.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`Complex.isAlgClosed` is the Mathlib instance that the complex numbers are algebraically closed.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Algebraic closure exists",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "Every field"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "AlgebraicClosure",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure",
+        "match_kind": "exact"
+      },
+      "note": "Mathlib constructs `AlgebraicClosure k` and provides algebraic and algebraically closed instances for it.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Algebraic closure",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "the roots in"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosure",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`IsAlgClosure F E` formalizes an algebraic closure as an algebraic algebra over `F` that is algebraically closed.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Algebraic closure uniqueness",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "Given two algebraic closures of"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosure.equiv",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`IsAlgClosure.equiv` gives an algebra equivalence between two algebraic closures over the same base field.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Algebraically closed fields in class hierarchy",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "Algebraically closed fields appear in the following chain of class inclusions"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed.perfectField",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib records some hierarchy consequences such as algebraically closed fields being perfect, but I found no formalized chain matching the article statement.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Real numbers example",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "the field of real numbers is not algebraically closed, because the polynomial equation"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsSemireal.not_isSumSq_neg_one",
+        "module": "Mathlib.Algebra.Ring.Semireal.Defs",
+        "match_kind": "generalization"
+      },
+      "note": "The semireal theorem gives related obstruction infrastructure for ordered fields, but I found no direct theorem stating that `ℝ` is not algebraically closed.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "No real subfield is algebraically closed",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "no subfield of the real field is algebraically closed"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsSemireal.not_isSumSq_neg_one",
+        "module": "Mathlib.Algebra.Ring.Semireal.Defs",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has semireal obstruction lemmas relevant to subfields of ordered fields, but I found no direct declaration that every subfield of `ℝ` is not algebraically closed.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Rational numbers not algebraically closed",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "the field of rational numbers is not algebraically closed"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polynomial.X_pow_sub_X_sub_one_irreducible_rat",
+        "module": "Mathlib.RingTheory.Polynomial.Selmer",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has explicit irreducible rational polynomials of degree greater than one, but I found no direct `¬ IsAlgClosed ℚ` theorem.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Fundamental theorem of algebra",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "the fundamental theorem of algebra states that the field of complex numbers is algebraically closed"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Complex.isAlgClosed",
+        "module": "Mathlib.Analysis.Complex.Polynomial.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`Complex.isAlgClosed` is Mathlib's formalization of the fundamental theorem of algebra in algebraically closed field form.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Algebraic numbers algebraically closed",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "Another example of an algebraically closed field is the field of (complex) algebraic numbers"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "AlgebraicClosure.isAlgClosed",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib proves an abstract algebraic closure is algebraically closed, but I found no declaration identifying the complex algebraic numbers as that field.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "No finite field is algebraically closed",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "No finite field F is algebraically closed"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosed.instInfinite",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`IsAlgClosed.instInfinite` proves every algebraically closed field is infinite, which is equivalent to excluding algebraically closed finite fields.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Union of finite fields fixed characteristic",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "the union of all finite fields of a fixed characteristic p ( p prime) is an algebraically closed field"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "GaloisField",
+        "module": "Mathlib.FieldTheory.Finite.GaloisField",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has finite Galois fields as splitting fields of `X^(p^n)-X`, but I found no theorem forming their union and proving it algebraically closed.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Algebraic closure of finite field",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "which is, in fact, the algebraic closure of the field"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "AlgebraicClosure",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has general algebraic closures, but I found no declaration identifying the fixed-characteristic finite-field union with `AlgebraicClosure (ZMod p)`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Complex rational function field not algebraically closed",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "of rational functions with complex coefficients is not closed"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "RatFunc.irreducible_minpolyX",
+        "module": "Mathlib.FieldTheory.RatFunc.AsPolynomial",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has rational-function-field and minpoly infrastructure, but I found no direct theorem that `RatFunc ℂ` is not algebraically closed.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Square root rational function roots absent",
+      "anchor": {
+        "section": "Examples",
+        "snippet": "for example, the polynomial"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "RatFunc.inftyValuation.X_zpow",
+        "module": "Mathlib.FieldTheory.RatFunc.Valuation",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has valuations on rational functions that can support such square-root obstructions, but I found no direct statement that the indicated polynomial has no root in `RatFunc ℂ`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Algebraic closedness has equivalent assertions",
+      "anchor": {
+        "section": "Equivalent properties",
+        "snippet": "the assertion \" F is algebraically closed\" is equivalent to other assertions"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed.algebraMap_bijective_of_isIntegral",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib formalizes several equivalent-looking consequences of algebraic closedness, but I found no bundled theorem listing all article equivalences.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Irreducible polynomials have degree one",
+      "anchor": {
+        "section": "The only irreducible polynomials are those of degree one",
+        "snippet": "The field F is algebraically closed if and only if the only irreducible polynomials in the polynomial ring F [ x ] are those of degree one"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed.degree_eq_one_of_irreducible",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib proves the algebraically-closed-to-linear-irreducible direction, but I found no exact iff theorem under this statement.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Linear polynomials irreducible",
+      "anchor": {
+        "section": "The only irreducible polynomials are those of degree one",
+        "snippet": "the polynomials of degree one are irreducible"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.irreducible_of_degree_eq_one",
+        "module": "Mathlib.Algebra.Polynomial.FieldDivision",
+        "match_kind": "exact"
+      },
+      "note": "`Polynomial.irreducible_of_degree_eq_one` states that a polynomial over a field with degree one is irreducible.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Irreducible polynomial over algebraically closed field is linear",
+      "anchor": {
+        "section": "The only irreducible polynomials are those of degree one",
+        "snippet": "If F is algebraically closed and p ( x ) is an irreducible polynomial of F [ x ]"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosed.degree_eq_one_of_irreducible",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`IsAlgClosed.degree_eq_one_of_irreducible` proves that irreducible polynomials over an algebraically closed field have degree one.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Non-algebraically closed field has irreducible polynomial of degree greater than one",
+      "anchor": {
+        "section": "The only irreducible polynomials are those of degree one",
+        "snippet": "if F is not algebraically closed, then there is some non-constant polynomial p ( x ) in F [ x ] without roots in F"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polynomial.exists_irreducible_of_degree_pos",
+        "module": "Mathlib.RingTheory.Polynomial.UniqueFactorization",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has irreducible-factor existence for positive-degree polynomials, but I found no direct contrapositive statement from `¬ IsAlgClosed` to a nonlinear irreducible polynomial.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Irreducible factor of rootless polynomial has no roots",
+      "anchor": {
+        "section": "The only irreducible polynomials are those of degree one",
+        "snippet": "Since p ( x ) has no roots in F , q ( x ) also has no roots in F"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.IsRoot.dvd",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs",
+        "match_kind": "generalization"
+      },
+      "note": "`Polynomial.IsRoot.dvd` gives the divisibility/root transfer whose contrapositive yields that a factor of a rootless polynomial has no root.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "First degree polynomial has a root",
+      "anchor": {
+        "section": "The only irreducible polynomials are those of degree one",
+        "snippet": "every first degree polynomial has one root in F"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.exists_root_of_degree_eq_one",
+        "module": "Mathlib.Algebra.Polynomial.FieldDivision",
+        "match_kind": "exact"
+      },
+      "note": "`Polynomial.exists_root_of_degree_eq_one` proves that every degree-one polynomial over a field has a root.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Polynomial splitting criterion",
+      "anchor": {
+        "section": "Every polynomial is a product of first degree polynomials",
+        "snippet": "The field F is algebraically closed if and only if every polynomial p ( x ) of degree n ≥ 1, with coefficients in F , splits into linear factors"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosed",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "Mathlib defines `IsAlgClosed` by the condition that every polynomial over the field splits.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Linear factor form",
+      "anchor": {
+        "section": "Every polynomial is a product of first degree polynomials",
+        "snippet": "there are elements k , x 1 , x 2 , ..., x n of the field F such that p ( x ) = k ( x − x 1 )( x − x 2 ) ⋯ ( x − x n )"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.splits_iff_exists_multiset",
+        "module": "Mathlib.Algebra.Polynomial.Splits",
+        "match_kind": "exact"
+      },
+      "note": "`Polynomial.splits_iff_exists_multiset` expresses splitting as a product of linear factors indexed by roots with a leading coefficient.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Root from splitting property",
+      "anchor": {
+        "section": "Every polynomial is a product of first degree polynomials",
+        "snippet": "If F has this property, then clearly every non-constant polynomial in F [ x ] has some root in F"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.Splits.exists_eval_eq_zero",
+        "module": "Mathlib.Algebra.Polynomial.Splits",
+        "match_kind": "exact"
+      },
+      "note": "`Polynomial.Splits.exists_eval_eq_zero` proves that a nonconstant split polynomial has a root.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Factorization into irreducibles",
+      "anchor": {
+        "section": "Every polynomial is a product of first degree polynomials",
+        "snippet": "for any field K , any polynomial in K [ x ] can be written as a product of irreducible polynomials"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.uniqueFactorizationMonoid",
+        "module": "Mathlib.RingTheory.Polynomial.UniqueFactorization",
+        "match_kind": "generalization"
+      },
+      "note": "`Polynomial.uniqueFactorizationMonoid` gives the unique-factorization structure on polynomial rings over fields, implying factorization into irreducibles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Prime degree root criterion",
+      "anchor": {
+        "section": "Polynomials of prime degree have roots",
+        "snippet": "If every polynomial over F of prime degree has a root in F , then every non-constant polynomial has a root in F"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polynomial.exists_irreducible_of_degree_pos",
+        "module": "Mathlib.RingTheory.Polynomial.UniqueFactorization",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has irreducible-factor infrastructure for positive-degree polynomials, but I found no theorem reducing root existence to prime-degree polynomials.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Algebraically closed iff prime degree roots",
+      "anchor": {
+        "section": "Polynomials of prime degree have roots",
+        "snippet": "a field is algebraically closed if and only if every polynomial over F of prime degree has a root in F"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed.exists_root",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib proves root existence for all positive-degree polynomials over algebraically closed fields, but I found no iff using only prime degrees.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "No proper algebraic extension criterion",
+      "anchor": {
+        "section": "The field has no proper algebraic extension",
+        "snippet": "The field F is algebraically closed if and only if it has no proper algebraic extension"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed.algebraMap_bijective_of_isIntegral",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib proves that an integral algebra over an algebraically closed field has bijective algebra map, but I found no exact iff packaged as no proper algebraic extensions.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Quotient by irreducible polynomial is algebraic extension",
+      "anchor": {
+        "section": "The field has no proper algebraic extension",
+        "snippet": "the quotient of F [ x ] modulo the ideal generated by p ( x ) is an algebraic extension of F whose degree is equal to the degree of p ( x )"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.finrank_quotient_span_eq_natDegree",
+        "module": "Mathlib.RingTheory.AdjoinRoot",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib proves the quotient by the span of a polynomial has finrank equal to its natDegree, with field structure for irreducible polynomials via `AdjoinRoot.instField`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Proper algebraic extension contains element with nonlinear minimal polynomial",
+      "anchor": {
+        "section": "The field has no proper algebraic extension",
+        "snippet": "if F has some proper algebraic extension K , then the minimal polynomial of an element in K \\ F is irreducible and its degree is greater than 1"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "minpoly.two_le_natDegree_iff",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "`minpoly.two_le_natDegree_iff` characterizes elements not coming from the base by minimal polynomial degree at least two, alongside the standard irreducibility of `minpoly`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "No proper finite extension criterion",
+      "anchor": {
+        "section": "The field has no proper finite extension",
+        "snippet": "The field F is algebraically closed if and only if it has no proper finite extension"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed.algebraMap_bijective_of_isIntegral",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has the algebraically-closed-to-trivial-integral-extension direction and finite extensions are algebraic, but I found no exact finite-extension iff theorem.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Finite extensions algebraic",
+      "anchor": {
+        "section": "The field has no proper finite extension",
+        "snippet": "Finite extensions are necessarily algebraic"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Algebra.IsAlgebraic.of_finite",
+        "module": "Mathlib.RingTheory.Algebraic.Integral",
+        "match_kind": "exact"
+      },
+      "note": "`Algebra.IsAlgebraic.of_finite` proves that a finite algebra extension is algebraic.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Eigenvector criterion",
+      "anchor": {
+        "section": "Every endomorphism of F n has some eigenvector",
+        "snippet": "The field F is algebraically closed if and only if, for each natural number n , every linear map from F n into itself has some eigenvector"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Module.End.exists_eigenvalue",
+        "module": "Mathlib.LinearAlgebra.Eigenspace.Triangularizable",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib proves the algebraically-closed-to-eigenvalue direction for finite-dimensional nontrivial spaces, but I found no converse iff criterion.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Eigenvector iff characteristic polynomial has root",
+      "anchor": {
+        "section": "Every endomorphism of F n has some eigenvector",
+        "snippet": "An endomorphism of F n has an eigenvector if and only if its characteristic polynomial has some root"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Module.End.hasEigenvalue_iff_isRoot_charpoly",
+        "module": "Mathlib.LinearAlgebra.Eigenspace.Charpoly",
+        "match_kind": "exact"
+      },
+      "note": "`Module.End.hasEigenvalue_iff_isRoot_charpoly` formalizes the equivalence between eigenvalues and roots of the characteristic polynomial.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Algebraic closedness gives eigenvectors",
+      "anchor": {
+        "section": "Every endomorphism of F n has some eigenvector",
+        "snippet": "when F is algebraically closed, every endomorphism of F n has some eigenvector"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Module.End.exists_eigenvalue",
+        "module": "Mathlib.LinearAlgebra.Eigenspace.Triangularizable",
+        "match_kind": "generalization"
+      },
+      "note": "`Module.End.exists_eigenvalue` proves that an endomorphism over an algebraically closed field on a nontrivial finite-dimensional space has an eigenvalue, yielding an eigenvector by existing eigenspace lemmas.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Monic rescaling preserves roots",
+      "anchor": {
+        "section": "Every endomorphism of F n has some eigenvector",
+        "snippet": "Dividing by its leading coefficient, we get another polynomial q ( x ) which has roots if and only if p ( x ) has roots"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.roots_C_mul",
+        "module": "Mathlib.Algebra.Polynomial.Roots",
+        "match_kind": "generalization"
+      },
+      "note": "`Polynomial.roots_C_mul` shows multiplication by a nonzero scalar does not change roots, which is the substance of monic rescaling preserving roots.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Companion matrix characteristic polynomial",
+      "anchor": {
+        "section": "Every endomorphism of F n has some eigenvector",
+        "snippet": "q ( x ) is the characteristic polynomial of the n×n companion matrix"
+      },
+      "status": "not_formalized",
+      "note": "I found characteristic-polynomial infrastructure but no verified companion-matrix declaration with this characteristic-polynomial theorem.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Partial fractions criterion",
+      "anchor": {
+        "section": "Decomposition of rational expressions",
+        "snippet": "The field F is algebraically closed if and only if every rational function in one variable x , with coefficients in F , can be written as the sum of a polynomial function with rational functions of the form a /( x − b ) n"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polynomial.div_prod_eq_quo_add_sum_rem_div",
+        "module": "Mathlib.Algebra.Polynomial.PartialFractions",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has a general partial-fraction decomposition theorem, but I found no iff criterion characterizing algebraically closed fields by linear-denominator decompositions.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Partial fractions over algebraically closed fields",
+      "anchor": {
+        "section": "Decomposition of rational expressions",
+        "snippet": "If F is algebraically closed then, since the irreducible polynomials in F [ x ] are all of degree 1, the property stated above holds by the theorem on partial fraction decomposition"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polynomial.div_prod_eq_quo_add_sum_rem_div",
+        "module": "Mathlib.Algebra.Polynomial.PartialFractions",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has the needed partial-fraction theorem and the linearity of irreducibles over algebraically closed fields, but I found no combined statement for this property.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Partial fractions force irreducibles linear",
+      "anchor": {
+        "section": "Decomposition of rational expressions",
+        "snippet": "suppose that the property stated above holds for the field F"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polynomial.div_prod_eq_quo_add_sum_rem_div",
+        "module": "Mathlib.Algebra.Polynomial.PartialFractions",
+        "match_kind": "special_case"
+      },
+      "note": "The partial-fraction machinery is present, but I found no theorem deriving linearity of irreducibles from the stated rational-function decomposition property.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Denominator product of linear polynomials",
+      "anchor": {
+        "section": "Decomposition of rational expressions",
+        "snippet": "can be written as a quotient of two polynomials in which the denominator is a product of first degree polynomials"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polynomial.splits_iff_exists_multiset",
+        "module": "Mathlib.Algebra.Polynomial.Splits",
+        "match_kind": "generalization"
+      },
+      "note": "`Polynomial.splits_iff_exists_multiset` formalizes products of linear factors, but I found no exact denominator-normalization theorem in the partial-fractions context.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Relatively prime polynomials have no common root",
+      "anchor": {
+        "section": "Relatively prime polynomials and roots",
+        "snippet": "For any field F , if two polynomials p ( x ), q ( x ) ∈ F [ x ] are relatively prime then they do not have a common root"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.aeval_ne_zero_of_isCoprime",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`Polynomial.aeval_ne_zero_of_isCoprime` proves that coprime polynomials cannot vanish at the same element.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Common-root converse characterizes algebraically closed fields",
+      "anchor": {
+        "section": "Relatively prime polynomials and roots",
+        "snippet": "The fields for which the reverse implication holds"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polynomial.isCoprime_iff_aeval_ne_zero_of_isAlgClosed",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib proves the coprime/common-root criterion over an algebraically closed field, but I found no theorem that the converse property characterizes algebraic closedness.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Non-coprime polynomials over algebraically closed field have common root",
+      "anchor": {
+        "section": "Relatively prime polynomials and roots",
+        "snippet": "If the field F is algebraically closed, let p ( x ) and q ( x ) be two polynomials which are not relatively prime"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Polynomial.isCoprime_iff_aeval_ne_zero_of_isAlgClosed",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`Polynomial.isCoprime_iff_aeval_ne_zero_of_isAlgClosed` gives the equivalence over algebraically closed fields, including the common-root consequence for non-coprime polynomials.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Non-algebraically closed counterexample to common-root converse",
+      "anchor": {
+        "section": "Relatively prime polynomials and roots",
+        "snippet": "If F is not algebraically closed, let p ( x ) be a polynomial whose degree is at least 1 without roots"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed.of_exists_root",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has a constructor from root existence for monic irreducibles to algebraic closedness, but I found no direct counterexample theorem for the failed common-root converse.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Algebraically closed fields contain roots of unity",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "If F is an algebraically closed field and n is a natural number, then F contains all n th roots of unity"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsSepClosed.hasEnoughRootsOfUnity",
+        "module": "Mathlib.RingTheory.RootsOfUnity.AlgebraicallyClosed",
+        "match_kind": "generalization"
+      },
+      "note": "`IsSepClosed.hasEnoughRootsOfUnity`, together with the instance from algebraically closed to separably closed, gives roots-of-unity existence under the usual nonzero-characteristic hypothesis for `n`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Cyclotomic extension",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "A field extension that is contained in an extension generated by the roots of unity is a cyclotomic extension"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsCyclotomicExtension",
+        "module": "Mathlib.NumberTheory.Cyclotomic.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`IsCyclotomicExtension` formalizes cyclotomic extensions using primitive roots of unity and generation by those roots.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Cyclotomic closure",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "the extension of a field generated by all roots of unity is sometimes called its cyclotomic closure"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsCyclotomicExtension.iff_adjoin_eq_top",
+        "module": "Mathlib.NumberTheory.Cyclotomic.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has cyclotomic-extension generation criteria, but I found no separate `CyclotomicClosure` definition.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Algebraically closed fields cyclotomically closed",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "Thus algebraically closed fields are cyclotomically closed"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsSepClosed.isCyclotomicExtension",
+        "module": "Mathlib.NumberTheory.Cyclotomic.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib proves separably closed fields give cyclotomic extensions in the formal `IsCyclotomicExtension` sense, but I found no statement using a `cyclotomically closed` predicate.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Cyclotomically closed converse false",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "The converse is not true"
+      },
+      "status": "not_formalized",
+      "note": "I found no verified Mathlib counterexample showing a cyclotomically closed field that is not algebraically closed.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Binomial splitting insufficient",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "Even assuming that every polynomial of the form x n − a splits into linear factors is not enough to assure that the field is algebraically closed"
+      },
+      "status": "not_formalized",
+      "note": "I found no verified Mathlib theorem or counterexample formalizing that splitting all binomials `X^n - a` is insufficient for algebraic closedness.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "First-order transfer for same characteristic",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "If a proposition which can be expressed in the language of first-order logic is true for an algebraically closed field, then it is true for every algebraically closed field with the same characteristic"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "FirstOrder.Field.ACF_isComplete",
+        "module": "Mathlib.ModelTheory.Algebra.Field.IsAlgClosed",
+        "match_kind": "generalization"
+      },
+      "note": "`FirstOrder.Field.ACF_isComplete` formalizes completeness of the theory of algebraically closed fields of fixed characteristic, giving the first-order transfer principle.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Lefschetz principle finite characteristic bound",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "if such a proposition is valid for an algebraically closed field with characteristic 0"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "FirstOrder.Field.ACF_zero_realize_iff_finite_ACF_prime_not_realize",
+        "module": "Mathlib.ModelTheory.Algebra.Field.IsAlgClosed",
+        "match_kind": "exact"
+      },
+      "note": "`FirstOrder.Field.ACF_zero_realize_iff_finite_ACF_prime_not_realize` formalizes the all-but-finitely-many-primes transfer from characteristic zero algebraically closed fields.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Algebraically closed extension exists",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "Every field F has some extension which is algebraically closed"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "AlgebraicClosure",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure",
+        "match_kind": "exact"
+      },
+      "note": "`AlgebraicClosure k` provides an algebraically closed field extension of any field `k`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Algebraically closed extension",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "Such an extension is called an algebraically closed extension"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsAlgClosed",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib represents an algebraically closed extension by an algebra structure whose target has an `IsAlgClosed` instance, but I found no separate named definition `AlgebraicallyClosedExtension`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Algebraic closure existence and uniqueness",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "Among all such extensions there is one and only one"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosure.equiv",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "Existence is provided by `AlgebraicClosure`, and `IsAlgClosure.equiv` gives uniqueness up to algebra equivalence.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Algebraic closure of a field",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "it is called the algebraic closure of F"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosure",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`IsAlgClosure F E` is the Mathlib predicate for `E` being an algebraic closure of `F`.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Quantifier elimination for algebraically closed fields",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "The theory of algebraically closed fields has quantifier elimination"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "FirstOrder.Language.Theory.ACF",
+        "module": "Mathlib.ModelTheory.Algebra.Field.IsAlgClosed",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib formalizes the first-order theory `ACF` and completeness results for it, but I found no quantifier-elimination theorem for algebraically closed fields.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "No algebraically closed finite field",
+      "anchor": {
+        "section": "Other properties",
+        "snippet": "There is no algebraically closed finite field"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsAlgClosed.instInfinite",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic",
+        "match_kind": "exact"
+      },
+      "note": "`IsAlgClosed.instInfinite` directly rules out finite algebraically closed fields by providing an infinite instance for any algebraically closed field.",
+      "provenance": "ai"
+    }
+  ]
+}

--- a/site/annotations/Hearing_the_shape_of_a_drum.json
+++ b/site/annotations/Hearing_the_shape_of_a_drum.json
@@ -1,0 +1,570 @@
+{
+  "slug": "Hearing_the_shape_of_a_drum",
+  "wikipedia_title": "Hearing the shape of a drum",
+  "display_title": "Hearing the shape of a drum",
+  "schema_version": 3,
+  "annotation_style": "theorem_article",
+  "annotations": [
+    {
+      "kind": "definition",
+      "label": "Hearing the shape problem",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "the conceptual problem of \" hearing the shape of a drum \" refers to the prospect of inferring information"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration formalizing Kac's inverse spectral problem of hearing the shape of a drum.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Frequencies depend on shape",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "The frequencies at which a drumhead can vibrate depend on its shape"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of drumhead vibration frequencies depending on planar shape.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Helmholtz equation frequencies",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "The Helmholtz equation calculates the frequencies if the shape is known"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "InnerProductSpace.laplacianWithin",
+        "module": "Mathlib.Analysis.InnerProductSpace.Laplacian",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib defines the Laplacian on finite-dimensional real inner product spaces, but I found no Helmholtz-equation frequency theorem for drum domains.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Frequencies as Laplacian eigenvalues",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "These frequencies are the eigenvalues of the Laplacian in the space"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Module.End.eigenspace",
+        "module": "Mathlib.LinearAlgebra.Eigenspace.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has general eigenspaces and Laplacian definitions, but no theorem identifying physical drum frequencies with Laplacian eigenvalues.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Central inverse question",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "A central question is whether the shape can be predicted if the frequencies are known"
+      },
+      "status": "not_formalized",
+      "note": "I found no declaration stating the inverse problem of recovering a shape from its frequency spectrum.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Reuleaux triangle example",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "whether a Reuleaux triangle can be recognized in this way"
+      },
+      "status": "not_formalized",
+      "note": "I found no Reuleaux-triangle inverse-spectral example or Reuleaux-triangle declaration in Mathlib.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Negative answer to Kac question",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "the frequencies determine the shape was finally answered in the negative"
+      },
+      "status": "not_formalized",
+      "note": "I found no formal statement of the negative answer to Kac's question in Mathlib.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Clamped membrane model",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "the drum is conceived as an elastic membrane whose boundary is clamped"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib model of an elastic membrane with clamped boundary conditions.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Drum domain",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "represented as a domain D in the plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no dedicated declaration for a drum domain as a planar domain in the inverse-spectral setting.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Dirichlet eigenvalues",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "Denote by λ n the Dirichlet eigenvalues for D"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Module.End.HasEigenvalue",
+        "module": "Mathlib.LinearAlgebra.Eigenspace.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib formalizes eigenvalues of linear endomorphisms, but I found no Dirichlet Laplacian eigenvalue sequence for a domain.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Isospectral domains",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "Two domains are said to be isospectral (or homophonic) if they have the same eigenvalues"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "spectrum",
+        "module": "Mathlib.Algebra.Algebra.Spectrum.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib defines spectra of algebra elements, but I found no isospectral-domain relation for Laplacian eigenvalues of planar domains.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Eigenvalues as tones",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "the Dirichlet eigenvalues are precisely the fundamental tones"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Module.End.HasEigenvalue",
+        "module": "Mathlib.LinearAlgebra.Eigenspace.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has eigenvalue infrastructure, but I found no formalization relating Dirichlet eigenvalues to fundamental tones.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Fourier coefficient occurrence",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "they appear naturally as Fourier coefficients"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "fourierCoeff",
+        "module": "Mathlib.Analysis.Fourier.AddCircle",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines Fourier coefficients on the additive circle, but I found no theorem that drum Dirichlet eigenvalues appear as such coefficients.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Inverse spectral formulation",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "what can be inferred on D if one knows only the values of λ n"
+      },
+      "status": "not_formalized",
+      "note": "I found no declaration formalizing the inverse spectral question for a domain from the values of its Dirichlet eigenvalues.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Isospectral nonuniqueness question",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "are there two distinct domains that are isospectral"
+      },
+      "status": "not_formalized",
+      "note": "I found no formalized existence question or theorem about distinct isospectral planar domains.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Higher-dimensional related problems",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "Dirichlet problem for the Laplacian on domains in higher dimensions or on Riemannian manifolds"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsRiemannianManifold",
+        "module": "Mathlib.Geometry.Manifold.Riemannian.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has Riemannian manifolds and Euclidean Laplacian infrastructure, but I found no Dirichlet spectral problem for higher-dimensional domains or manifolds.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Other elliptic operators",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "Cauchy–Riemann operator or Dirac operator"
+      },
+      "status": "not_formalized",
+      "note": "I found no Cauchy-Riemann or Dirac elliptic-operator declarations corresponding to this example.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Neumann boundary condition",
+      "anchor": {
+        "section": "Formal statement",
+        "snippet": "the Neumann boundary condition"
+      },
+      "status": "not_formalized",
+      "note": "I found no Neumann boundary-condition formalization for PDE eigenvalue problems in Mathlib.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Milnor isospectral tori",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "the existence of a pair of 16-dimensional flat tori"
+      },
+      "status": "not_formalized",
+      "note": "I found no formalization of Milnor's pair of 16-dimensional isospectral flat tori.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Gordon-Webb-Wolpert domains",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "a pair of regions in the plane that have different shapes but identical eigenvalues"
+      },
+      "status": "not_formalized",
+      "note": "I found no declaration for the Gordon-Webb-Wolpert noncongruent isospectral planar domains.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Concave polygon regions",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "The regions are concave polygons"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Polygon",
+        "module": "Mathlib.Geometry.Polygon.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib defines general polygons, but I found no concave-polygon classification of the Gordon-Webb-Wolpert regions.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Similar isospectral examples",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "constructed numerous similar examples"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declarations for families of planar isospectral examples similar to Gordon-Webb-Wolpert.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Inaudibility for many shapes",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "for many shapes, one cannot hear the shape of the drum completely"
+      },
+      "status": "not_formalized",
+      "note": "I found no theorem in Mathlib stating non-uniqueness of shape from spectrum for many drums.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Partial spectral information",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "some information can be inferred"
+      },
+      "status": "not_formalized",
+      "note": "I found no formal statement of geometric information inferable from the Dirichlet spectrum of a drum domain.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Zelditch positive result",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "the answer to Kac's question is positive if one imposes restrictions to certain convex planar regions with analytic boundary"
+      },
+      "status": "not_formalized",
+      "note": "I found no formalization of Zelditch's positive inverse-spectral result for restricted convex analytic planar domains.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Non-convex analytic open problem",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "two non-convex analytic domains can have the same eigenvalues"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib statement of the open problem about isospectral non-convex analytic domains.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Compact isospectral domains",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "the set of domains isospectral with a given one is compact"
+      },
+      "status": "not_formalized",
+      "note": "I found no theorem that the class of domains isospectral to a fixed domain is compact.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Sphere spectral rigidity",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "the sphere (for instance) is spectrally rigid"
+      },
+      "status": "not_formalized",
+      "note": "I found no spectral-rigidity theorem for spheres in Mathlib.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "No continuous isospectral flow",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "the moduli space of Riemann surfaces of a given genus does not admit a continuous isospectral flow"
+      },
+      "status": "not_formalized",
+      "note": "I found no formalization of a no-continuous-isospectral-flow theorem for moduli spaces of Riemann surfaces.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Compact moduli space",
+      "anchor": {
+        "section": "The answer",
+        "snippet": "is compact in the Fréchet–Schwartz topology"
+      },
+      "status": "not_formalized",
+      "note": "I found no declaration for the relevant moduli space or its compactness in the Frechet-Schwartz topology.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Weyl area formula",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "Weyl's formula states that one can infer the area A of the drum"
+      },
+      "status": "not_formalized",
+      "note": "I found no Weyl eigenvalue-counting asymptotic that recovers the area of a drum domain.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Eigenvalue counting function",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "N ( R ) to be the number of eigenvalues smaller than R"
+      },
+      "status": "not_formalized",
+      "note": "I found no eigenvalue-counting function for spectra of Dirichlet Laplacians in Mathlib.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Dimension parameter",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "d is the dimension"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "Module.finrank",
+        "module": "Mathlib.LinearAlgebra.Dimension.Finrank",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib formalizes finite dimension as the natural number `Module.finrank`, though not specifically as the parameter in Weyl's formula.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Unit ball volume",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "volume of the d -dimensional unit ball"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "EuclideanSpace.volume_ball",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls",
+        "match_kind": "generalization"
+      },
+      "note": "`EuclideanSpace.volume_ball` gives the volume formula for Euclidean balls, including the d-dimensional unit ball as a special invocation.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Weyl perimeter conjecture",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "the next term in the approximation below would give the perimeter of D"
+      },
+      "status": "not_formalized",
+      "note": "I found no statement of Weyl's perimeter-term conjecture for drum spectra.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Perimeter length notation",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "L denotes the length of the perimeter"
+      },
+      "status": "not_formalized",
+      "note": "I found no perimeter-length notation or perimeter functional for planar drum domains tied to this formula.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Weyl two-term asymptotic",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "then one should have"
+      },
+      "status": "not_formalized",
+      "note": "I found no two-term Weyl asymptotic for the Dirichlet eigenvalue counting function in Mathlib.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Ivrii smooth-boundary theorem",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "For a smooth boundary, this was proved"
+      },
+      "status": "not_formalized",
+      "note": "I found no formalization of Ivrii's smooth-boundary two-term Weyl theorem.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Periodic geodesic exclusion",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "not allowed to have a two-parameter family of periodic geodesics"
+      },
+      "status": "not_formalized",
+      "note": "I found no theorem excluding two-parameter families of periodic geodesics for Weyl asymptotics.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Sphere periodic geodesics",
+      "anchor": {
+        "section": "Weyl's formula",
+        "snippet": "such as a sphere would have"
+      },
+      "status": "not_formalized",
+      "note": "I found no formal statement that spheres have the relevant two-parameter family of periodic geodesics.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Weyl-Berry correction",
+      "anchor": {
+        "section": "The Weyl–Berry conjecture",
+        "snippet": "the correction should be of the order of"
+      },
+      "status": "not_formalized",
+      "note": "I found no statement of the Weyl-Berry spectral correction order in Mathlib.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Boundary Hausdorff dimension",
+      "anchor": {
+        "section": "The Weyl–Berry conjecture",
+        "snippet": "D is the Hausdorff dimension of the boundary"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "dimH",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDimension",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib defines Hausdorff dimension of arbitrary metric-space sets via `dimH`, but I found no Weyl-Berry boundary-dimension parameterization.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Brossard-Carmona disproof",
+      "anchor": {
+        "section": "The Weyl–Berry conjecture",
+        "snippet": "This was disproved by J. Brossard and R. A. Carmona"
+      },
+      "status": "not_formalized",
+      "note": "I found no formalization of the Brossard-Carmona disproof of the Weyl-Berry conjecture.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Upper box dimension replacement",
+      "anchor": {
+        "section": "The Weyl–Berry conjecture",
+        "snippet": "replace the Hausdorff dimension with the upper box dimension"
+      },
+      "status": "not_formalized",
+      "note": "I found no upper box dimension replacement statement, and no upper box dimension declaration, in Mathlib.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Planar dimension-one case",
+      "anchor": {
+        "section": "The Weyl–Berry conjecture",
+        "snippet": "this was proved if the boundary has dimension 1"
+      },
+      "status": "not_formalized",
+      "note": "I found no theorem proving the Weyl-Berry replacement in the planar boundary-dimension-one case.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Higher-dimensional disproof",
+      "anchor": {
+        "section": "The Weyl–Berry conjecture",
+        "snippet": "mostly disproved for higher dimensions"
+      },
+      "status": "not_formalized",
+      "note": "I found no higher-dimensional disproof theorem for the Weyl-Berry conjectural correction in Mathlib.",
+      "provenance": "ai"
+    }
+  ]
+}

--- a/site/annotations/Hyperbolic_geometry.json
+++ b/site/annotations/Hyperbolic_geometry.json
@@ -1,0 +1,2735 @@
+{
+  "slug": "Hyperbolic_geometry",
+  "wikipedia_title": "Hyperbolic geometry",
+  "display_title": "Hyperbolic geometry",
+  "schema_version": 3,
+  "annotation_style": "theorem_article",
+  "annotations": [
+    {
+      "kind": "definition",
+      "label": "Hyperbolic geometry",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "hyperbolic geometry (also called Lobachevskian geometry or Bolyai – Lobachevskian geometry ) is a non-Euclidean geometry"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.dist_eq",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines the Poincare hyperbolic metric on the upper half-plane, but not an axiomatic non-Euclidean geometry called hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic parallel postulate",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "The parallel postulate of Euclidean geometry is replaced with:"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration formalizing the hyperbolic parallel postulate.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "At least two parallels through an external point",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "there are at least two distinct lines through P that do not intersect R"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for existence of multiple hyperbolic parallels through an external point.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperbolic plane",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "The hyperbolic plane is a plane where every point is a saddle point"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Basic",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib has the upper half-plane model type, but I found no saddle-point or curvature definition of the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Pseudospherical surface geometry",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "Hyperbolic plane geometry is also the geometry of pseudospherical surfaces"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration connecting hyperbolic plane geometry with pseudospherical surfaces.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Saddle surfaces have negative curvature",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "Saddle surfaces have negative Gaussian curvature in at least some regions"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for Gaussian curvature of saddle surfaces.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperboloid model events",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "The hyperboloid model of hyperbolic geometry provides a representation of events one temporal unit into the future in Minkowski space"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for the hyperboloid model or its interpretation as Minkowski-space events.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Events correspond to rapidities",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "Each of these events corresponds to a rapidity in some direction"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration relating hyperboloid-model events to rapidities.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Parallel postulate is only axiomatic difference",
+      "anchor": {
+        "section": "Relation to Euclidean geometry",
+        "snippet": "the only axiomatic difference is the parallel postulate"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib axiomatization comparing Euclidean and hyperbolic geometry by only the parallel postulate.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Absolute geometry",
+      "anchor": {
+        "section": "Relation to Euclidean geometry",
+        "snippet": "When the parallel postulate is removed from Euclidean geometry the resulting geometry is absolute geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration defining absolute geometry as Euclidean geometry without the parallel postulate.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Kinds of absolute geometry",
+      "anchor": {
+        "section": "Relation to Euclidean geometry",
+        "snippet": "There are two kinds of absolute geometry, Euclidean and hyperbolic"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib classification of absolute geometries into Euclidean and hyperbolic cases.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Absolute geometry theorems hold",
+      "anchor": {
+        "section": "Relation to Euclidean geometry",
+        "snippet": "All theorems of absolute geometry, including the first 28 propositions of book one of Euclid's Elements , are valid in Euclidean and hyperbolic geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration formalizing this transfer of absolute-geometry theorems.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Euclid I.27-I.28 parallel lines",
+      "anchor": {
+        "section": "Relation to Euclidean geometry",
+        "snippet": "Propositions 27 and 28 of Book One of Euclid's Elements prove the existence of parallel/non-intersecting lines"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration corresponding to Euclid I.27 or I.28 as propositions about parallel lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Euclidean equivalences may fail hyperbolically",
+      "anchor": {
+        "section": "Relation to Euclidean geometry",
+        "snippet": "concepts that are equivalent in Euclidean geometry are not equivalent in hyperbolic geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration comparing Euclidean equivalences with hyperbolic failures.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Absolute scale",
+      "anchor": {
+        "section": "Relation to Euclidean geometry",
+        "snippet": "hyperbolic geometry has an absolute scale , a relation between distance and angle measurements"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.dist_eq",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "invocation"
+      },
+      "note": "The upper-half-plane distance is formalized with a fixed scale, but no declaration states the absolute-scale principle involving distances and angles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Single-line properties match Euclidean geometry",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "Single lines in hyperbolic geometry have exactly the same properties as single straight lines in Euclidean geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of hyperbolic lines supporting this comparison.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Two points define a line",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "two points uniquely define a line"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "affineSpan_pair_le",
+        "module": "Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Defs",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib formalizes the affine line through two points and its minimality in affine geometry, but not for hyperbolic lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Line segments extend infinitely",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "line segments can be infinitely extended"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "AffineMap.lineMap",
+        "module": "Mathlib.LinearAlgebra.AffineSpace.AffineMap",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib has affine line parameterizations over a scalar field, but no hyperbolic line-segment extension theorem.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Intersecting-line properties match Euclidean geometry",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "Two intersecting lines have the same properties as two intersecting lines in Euclidean geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem comparing intersecting hyperbolic lines with Euclidean ones.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Distinct lines intersect at most once",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "two distinct lines can intersect in no more than one point"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "AffineMap.lineMap_injective",
+        "module": "Mathlib.LinearAlgebra.AffineSpace.AffineMap",
+        "match_kind": "generalization"
+      },
+      "note": "Mathlib proves injectivity of nondegenerate affine line parameterizations, but not the hyperbolic line-intersection statement.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Intersecting lines form equal opposite angles",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "intersecting lines form equal opposite angles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for vertical opposite angles of hyperbolic intersecting lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Adjacent angles are supplementary",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "adjacent angles of intersecting lines are supplementary"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for supplementary adjacent angles of hyperbolic intersecting lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Many lines avoid two intersecting lines",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "given two intersecting lines there are infinitely many lines that do not intersect either of the given lines"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about infinitely many hyperbolic lines avoiding two intersecting lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Line properties are model-independent",
+      "anchor": {
+        "section": "Lines",
+        "snippet": "These properties are all independent of the model used"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration proving model-independence of hyperbolic line properties.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Non-intersecting lines differ from Euclidean case",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "Non-intersecting lines in hyperbolic geometry also have properties that differ from non-intersecting lines in Euclidean geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration comparing non-intersecting hyperbolic and Euclidean lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "At least two non-intersecting lines",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "there are at least two distinct lines through P that do not intersect R"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for two non-intersecting hyperbolic lines through an external point.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Infinitely many hyperbolic parallels",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "there are through P an infinite number of coplanar lines that do not intersect R"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem asserting infinitely many hyperbolic parallels through a point.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Two classes of non-intersecting lines",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "These non-intersecting lines are divided into two classes"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition classifying non-intersecting hyperbolic lines into limiting-parallel and ultraparallel classes.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Limiting parallels",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "Two of the lines ( x and y in the diagram) are limiting parallels"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of limiting parallel lines in hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Ultraparallel lines",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "All other non-intersecting lines have a point of minimum distance and diverge from both sides of that point, and are called ultraparallel"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of ultraparallel hyperbolic lines or their minimum-distance property.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Parallel lines as limiting parallels",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "Some geometers simply use the phrase \" parallel lines\" to mean \" limiting parallel lines\""
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib convention defining hyperbolic parallel lines to mean limiting parallels.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Angle of parallelism",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "This angle depends only on the Gaussian curvature of the plane and the distance PB and is called the angle of parallelism"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration defining the hyperbolic angle of parallelism.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Ultraparallel theorem",
+      "anchor": {
+        "section": "Non-intersecting / parallel lines",
+        "snippet": "there is a unique line in the hyperbolic plane that is perpendicular to each pair of ultraparallel lines"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about a unique common perpendicular to ultraparallel hyperbolic lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Circle circumference lower bound",
+      "anchor": {
+        "section": "Circles and disks",
+        "snippet": "the circumference of a circle of radius r is greater than"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.image_coe_sphere",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib identifies upper-half-plane metric spheres with Euclidean spheres, but it does not prove the hyperbolic circumference lower bound.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic Gaussian curvature is negative",
+      "anchor": {
+        "section": "Circles and disks",
+        "snippet": "In hyperbolic geometry,"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration proving negative Gaussian curvature for the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Circle circumference formula",
+      "anchor": {
+        "section": "Circles and disks",
+        "snippet": "Then the circumference of a circle of radius r is equal to:"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.image_coe_sphere",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib formalizes metric spheres in the upper half-plane model, but I found no hyperbolic circle circumference formula.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Disk area formula",
+      "anchor": {
+        "section": "Circles and disks",
+        "snippet": "And the area of the enclosed disk is:"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.volume_eq_lintegral",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Measure",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines the invariant upper-half-plane measure and gives an integral expression, but not the closed-form disk area formula.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Circumference-to-radius ratio",
+      "anchor": {
+        "section": "Circles and disks",
+        "snippet": "the ratio of a circle's circumference to its radius is always strictly greater than"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem comparing hyperbolic circle circumference-to-radius ratios with Euclidean ones.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Small-circle Euclidean limit",
+      "anchor": {
+        "section": "Circles and disks",
+        "snippet": "it can be made arbitrarily close by selecting a small enough circle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for the Euclidean small-radius limit of hyperbolic circles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Circle geodesic curvature formula",
+      "anchor": {
+        "section": "Circles and disks",
+        "snippet": "If the Gaussian curvature of the plane is −1 then the geodesic curvature of a circle of radius r is:"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for geodesic curvature of hyperbolic circles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "No equidistant line",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "there is no line whose points are all equidistant from another line"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem saying there are no equidistant hyperbolic lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hypercycle",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "the points that are all the same distance from a given line lie on a curve called a hypercycle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of hypercycles in hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Horocycle",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "Another special curve is the horocycle , whose normal radii ( perpendicular lines) are all limiting parallel to each other"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of horocycles in hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Two horocycles through two points",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "Through every pair of points there are two horocycles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem on existence of two horocycles through two points.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Horocycle centers for two points",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "The centres of the horocycles are the ideal points of the perpendicular bisector of the line-segment between them"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about centers of horocycles through two points.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Three-point curve classification",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "Given any three distinct points, they all lie on either a line, hypercycle, horocycle , or circle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib classification of three points by hyperbolic line, hypercycle, horocycle, or circle.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Line-segment length",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "The length of a line-segment is the shortest length between two points"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.dist_eq",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines hyperbolic distance on the upper half-plane, but not line-segment length as a minimizing geodesic length.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hypercycle arc length bounds",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "The arc-length of a hypercycle connecting two points is longer than that of the line segment and shorter than that of the arc horocycle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem comparing hypercycle, segment, and horocycle arc lengths.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Horocycle arc length equality and bounds",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "The lengths of the arcs of both horocycles connecting two points are equal"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about equality or bounds for horocycle arc lengths.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Horocycle geodesic curvature",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "the geodesic curvature of a horocycle is 1"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for geodesic curvature of horocycles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hypercycle geodesic curvature",
+      "anchor": {
+        "section": "Hypercycles and horocycles",
+        "snippet": "that of a hypercycle is between 0 and 1"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for geodesic curvature bounds of hypercycles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic triangle angle sum",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "the sum of the angles of a triangle is always strictly less than π radians (180°)"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for the angle sum of hyperbolic triangles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Triangle defect",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "The difference is called the defect"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of hyperbolic triangle defect.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Convex hyperbolic polygon defect",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "the defect of a convex hyperbolic polygon with"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of defect for convex hyperbolic polygons.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Hyperbolic triangle area by defect",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "The area of a hyperbolic triangle is given by its defect in radians multiplied by R 2"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem giving hyperbolic triangle area by angular defect.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Convex hyperbolic polygon area by defect",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "which is also true for all convex hyperbolic polygons"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem giving convex hyperbolic polygon area by angular defect.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic triangle area bound",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "all hyperbolic triangles have an area less than or equal to R 2 π"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem bounding areas of hyperbolic triangles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Ideal triangle maximal area",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "The area of a hyperbolic ideal triangle in which all three angles are 0° is equal to this maximum"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for ideal hyperbolic triangles or their maximal area.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic triangle incircle",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "each hyperbolic triangle has an incircle"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Affine.Simplex.insphere",
+        "module": "Mathlib.Geometry.Euclidean.Incenter",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib defines Euclidean simplex inspheres, but I found no hyperbolic triangle incircle theorem.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "No circumcircle for horocyclic or hypercyclic vertices",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "if all three of its vertices lie on a horocycle or hypercycle , then the triangle has no circumscribed circle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about circumcircles of triangles with horocyclic or hypercyclic vertices.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Hyperbolic AAA congruence",
+      "anchor": {
+        "section": "Triangles",
+        "snippet": "if two triangles are similar, they must be congruent"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem formalizing AAA congruence for hyperbolic triangles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Regular apeirogon and pseudogon",
+      "anchor": {
+        "section": "Regular apeirogon and pseudogon",
+        "snippet": "Special polygons in hyperbolic geometry are the regular apeirogon and pseudogon uniform polygons with an infinite number of sides"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definitions of regular apeirogons or pseudogons in hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Euclidean apeirogon construction degenerates",
+      "anchor": {
+        "section": "Regular apeirogon and pseudogon",
+        "snippet": "the only way to construct such a polygon is to make the side lengths tend to zero"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about Euclidean regular apeirogon degeneration.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic apeirogon or pseudogon side lengths",
+      "anchor": {
+        "section": "Regular apeirogon and pseudogon",
+        "snippet": "a regular apeirogon or pseudogon has sides of any length"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about side lengths of hyperbolic regular apeirogons or pseudogons.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Apeirogon via limiting bisectors",
+      "anchor": {
+        "section": "Regular apeirogon and pseudogon",
+        "snippet": "If the bisectors are limiting parallel then it is an apeirogon"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of apeirogons via limiting-parallel bisectors.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Apeirogon horocycle inscription",
+      "anchor": {
+        "section": "Regular apeirogon and pseudogon",
+        "snippet": "can be inscribed and circumscribed by concentric horocycles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem on horocycle inscription or circumscription of apeirogons.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Pseudogon via diverging bisectors",
+      "anchor": {
+        "section": "Regular apeirogon and pseudogon",
+        "snippet": "If the bisectors are diverging parallel then it is a pseudogon"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of pseudogons via diverging-parallel bisectors.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Pseudogon hypercycle inscription",
+      "anchor": {
+        "section": "Regular apeirogon and pseudogon",
+        "snippet": "can be inscribed and circumscribed by hypercycles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem on hypercycle inscription or circumscription of pseudogons.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Regular tessellation of hyperbolic plane",
+      "anchor": {
+        "section": "Tessellations",
+        "snippet": "it is also possible to tessellate the hyperbolic plane with regular polygons as faces"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem constructing regular tessellations of the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Infinitely many Schwarz-triangle uniform tilings",
+      "anchor": {
+        "section": "Tessellations",
+        "snippet": "There are an infinite number of uniform tilings based on the Schwarz triangles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about infinitely many Schwarz-triangle uniform hyperbolic tilings.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperbolic triangle group",
+      "anchor": {
+        "section": "Tessellations",
+        "snippet": "the symmetry group is a hyperbolic triangle group"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of hyperbolic triangle groups for tilings.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Infinitely many non-Schwarz uniform tilings",
+      "anchor": {
+        "section": "Tessellations",
+        "snippet": "There are also infinitely many uniform tilings that cannot be generated from Schwarz triangles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about non-Schwarz uniform tilings of the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Quadrilateral fundamental domains",
+      "anchor": {
+        "section": "Tessellations",
+        "snippet": "some for example requiring quadrilaterals as fundamental domains"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib examples of hyperbolic tilings requiring quadrilateral fundamental domains.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Standardized curvature scale",
+      "anchor": {
+        "section": "Standardized Gaussian curvature",
+        "snippet": "it is usual to assume a scale in which the curvature K is −1"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.dist_eq",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib uses a standard upper-half-plane metric normalization, but I found no Gaussian-curvature scale declaration stating K = -1.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Triangle area at curvature minus one",
+      "anchor": {
+        "section": "Standardized Gaussian curvature",
+        "snippet": "The area of a triangle is equal to its angle defect in radians"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem that hyperbolic triangle area equals angular defect at curvature -1.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Horocyclic sector area",
+      "anchor": {
+        "section": "Standardized Gaussian curvature",
+        "snippet": "The area of a horocyclic sector is equal to the length of its horocyclic arc"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem relating horocyclic sector area to horocycle arc length.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Unit horocycle arc",
+      "anchor": {
+        "section": "Standardized Gaussian curvature",
+        "snippet": "An arc of a horocycle so that a line that is tangent at one endpoint is limiting parallel to the radius through the other endpoint has a length of 1"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about unit-length arcs of horocycles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Concentric horocycle arc ratio",
+      "anchor": {
+        "section": "Standardized Gaussian curvature",
+        "snippet": "The ratio of the arc lengths between two radii of two concentric horocycles where the horocycles are a distance 1 apart is e : 1"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for arc-length ratios of concentric horocycles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Coordinate-system difficulties",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "hyperbolic geometry presents many difficulties for a coordinate system"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration formalizing this qualitative claim about coordinate-system difficulties.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Quadrilateral angle sum",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "the angle sum of a quadrilateral is always less than 360°"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for quadrilateral angle sums in the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "No equidistant lines",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "there are no equidistant lines"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem that hyperbolic geometry has no equidistant lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperbolic rectangle boundary",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "a proper rectangle would need to be enclosed by two lines and two hypercycles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of hyperbolic rectangles bounded by lines and hypercycles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Parallel transport rotation",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "parallel-transporting a line segment around a quadrilateral causes it to rotate when it returns to the origin"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about holonomy or parallel transport around hyperbolic quadrilaterals.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperbolic coordinate systems",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "All are based around choosing a point (the origin) on a chosen directed line (the x -axis)"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of these hyperbolic coordinate systems from an origin and directed axis.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Lobachevsky coordinates",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "The Lobachevsky coordinates x and y are found by dropping a perpendicular onto the x -axis"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of Lobachevsky coordinates on the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Lobachevsky x-coordinate",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "x will be the label of the foot of the perpendicular"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for the Lobachevsky x-coordinate as a perpendicular-foot label.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Lobachevsky y-coordinate",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "y will be the distance along the perpendicular of the given point from its foot"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for the Lobachevsky y-coordinate as perpendicular distance.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Horocycle coordinate system",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "Another coordinate system measures the distance from the point to the horocycle through the origin centered around"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of horocycle-based coordinates.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Model-based coordinates",
+      "anchor": {
+        "section": "Cartesian-like coordinate systems",
+        "snippet": "Other coordinate systems use the Klein model or the Poincaré disk model described below"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Complex.UnitDisc",
+        "module": "Mathlib.Analysis.Complex.UnitDisc.Basic",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines the complex unit disk, but not Klein-model or Poincare-disk hyperbolic coordinate systems.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Cartesian-like coordinates",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "A Cartesian-like [ citation needed ] coordinate system ( x, y ) on the oriented hyperbolic plane is constructed as follows"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the article's Cartesian-like hyperbolic coordinates.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Cartesian-like x-coordinate",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "the x -coordinate of a point is the signed distance of its projection onto the line"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for this Cartesian-like hyperbolic x-coordinate.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Cartesian-like y-coordinate",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "the y -coordinate is the signed distance from the point to the line"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for this Cartesian-like hyperbolic y-coordinate.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Distance formula",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "The distance between two points represented by ( x_i, y_i ), i=1,2 in this coordinate system is"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.dist_eq",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib gives a hyperbolic distance formula for upper-half-plane points, but not the article's Cartesian-like coordinate formula.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Metric tensor field",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "The corresponding metric tensor field is:"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for the metric tensor field in these hyperbolic coordinates.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Straight-line forms",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "In this coordinate system, straight lines take one of these forms"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib classification of hyperbolic line equations in this coordinate system.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Ultraparallel line form",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "ultraparallel to the x -axis"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib equation for ultraparallel lines in these coordinates.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Negative-side asymptotic line form",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "asymptotically parallel on the negative side"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib equation for negative-side asymptotically parallel lines in these coordinates.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Positive-side asymptotic line form",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "asymptotically parallel on the positive side"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib equation for positive-side asymptotically parallel lines in these coordinates.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Perpendicular-intersecting line form",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "intersecting perpendicularly"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib equation for perpendicular-intersecting hyperbolic lines in these coordinates.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Angled-intersecting line form",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "intersecting at an angle α"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib equation for hyperbolic lines intersecting at a prescribed angle in these coordinates.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Line equations bounded domain",
+      "anchor": {
+        "section": "Distance",
+        "snippet": "these equations will only hold in a bounded domain"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about bounded domains of validity for these line equations.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Parallel postulate independence",
+      "anchor": {
+        "section": "History",
+        "snippet": "the parallel postulate is not provable from the other postulates"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib independence proof for Euclid's parallel postulate.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Early quadrilateral theorems",
+      "anchor": {
+        "section": "History",
+        "snippet": "The theorems of Alhacen, Khayyam and al-Tūsī on quadrilaterals"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declarations for the historical Alhacen, Khayyam, or al-Tusi quadrilateral theorems.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Hyperbolic functions",
+      "anchor": {
+        "section": "History",
+        "snippet": "Johann Heinrich Lambert introduced the hyperbolic functions"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Real.sinh",
+        "module": "Mathlib.Analysis.Complex.Trigonometric",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines hyperbolic functions such as Real.sinh and Real.cosh, but not the historical assertion about Lambert introducing them.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Lambert triangle area computation",
+      "anchor": {
+        "section": "History",
+        "snippet": "computed the area of a hyperbolic triangle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for Lambert's hyperbolic triangle area computation.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic geometry self-consistency",
+      "anchor": {
+        "section": "19th-century developments",
+        "snippet": "argued that hyperbolic geometry is self-consistent"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of self-consistency of hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Beltrami relative consistency",
+      "anchor": {
+        "section": "19th-century developments",
+        "snippet": "used this to prove that hyperbolic geometry was consistent if and only if Euclidean geometry was"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for Beltrami's relative consistency result.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Cayley-Klein metric construction",
+      "anchor": {
+        "section": "19th-century developments",
+        "snippet": "The idea used a conic section or quadric to define a region, and used cross ratio to define a metric"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib construction of the Cayley-Klein metric from a conic or quadric and cross-ratio.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Projective transformations as isometries",
+      "anchor": {
+        "section": "19th-century developments",
+        "snippet": "The projective transformations that leave the conic section or quadric stable are the isometries"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.coe_smul",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib formalizes fractional linear actions on the upper half-plane, but not the Cayley-Klein projective-isometry theorem for a conic or quadric.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Klein Cayley absolute theorem",
+      "anchor": {
+        "section": "19th-century developments",
+        "snippet": "if the Cayley absolute is a real curve then the part of the projective plane in its interior is isometric to the hyperbolic plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem identifying the interior of a real Cayley absolute with the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic geometry consistency",
+      "anchor": {
+        "section": "Philosophical consequences",
+        "snippet": "Hyperbolic geometry was finally proved consistent and is therefore another valid geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib consistency proof for hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Possible spatial geometries",
+      "anchor": {
+        "section": "Geometry of the universe (spatial dimensions only)",
+        "snippet": "Euclidean, hyperbolic and elliptic geometry are all consistent"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem jointly proving consistency of Euclidean, hyperbolic, and elliptic geometries.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Lobachevsky curvature lower bound conclusion",
+      "anchor": {
+        "section": "Geometry of the universe (spatial dimensions only)",
+        "snippet": "if the geometry of the universe is hyperbolic, then the absolute length is at least one million times the diameter of Earth's orbit"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of Lobachevsky's astronomical lower bound on hyperbolic curvature scale.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Sphere-world thought experiment",
+      "anchor": {
+        "section": "Geometry of the universe (spatial dimensions only)",
+        "snippet": "everyday experience does not necessarily rule out other geometries"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of this sphere-world thought experiment or its conclusion.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Geometrization possibilities",
+      "anchor": {
+        "section": "Geometry of the universe (spatial dimensions only)",
+        "snippet": "The geometrization conjecture gives a complete list of eight possibilities for the fundamental geometry of our space"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of Thurston geometrization or the list of eight model geometries.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Relativity unifies space and time",
+      "anchor": {
+        "section": "Geometry of the universe (special relativity)",
+        "snippet": "Special relativity places space and time on equal footing"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration formalizing this special-relativity statement.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Minkowski geometry",
+      "anchor": {
+        "section": "Geometry of the universe (special relativity)",
+        "snippet": "Minkowski geometry replaces Galilean geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of Minkowski spacetime geometry replacing Galilean geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Relativistic curvature geometries",
+      "anchor": {
+        "section": "Geometry of the universe (special relativity)",
+        "snippet": "the appropriate geometries to consider are Minkowski space , de Sitter space and anti-de Sitter space"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration classifying relativistic geometries as Minkowski, de Sitter, and anti-de Sitter spaces.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Rapidity as hyperbolic angle",
+      "anchor": {
+        "section": "Geometry of the universe (special relativity)",
+        "snippet": "rapidity , which stands in for velocity , and is expressed by a hyperbolic angle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of rapidity as a hyperbolic angle.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Kinematic geometry",
+      "anchor": {
+        "section": "Geometry of the universe (special relativity)",
+        "snippet": "The study of this velocity geometry has been called kinematic geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of kinematic geometry as relativistic velocity geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Velocity space is hyperbolic",
+      "anchor": {
+        "section": "Geometry of the universe (special relativity)",
+        "snippet": "The space of relativistic velocities has a three-dimensional hyperbolic geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem that relativistic velocity space has three-dimensional hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Velocity-space distance",
+      "anchor": {
+        "section": "Geometry of the universe (special relativity)",
+        "snippet": "the distance function is determined from the relative velocities of \"nearby\" points"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of a relativistic velocity-space distance function.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Pseudospheres in Euclidean space",
+      "anchor": {
+        "section": "Physical realizations of the hyperbolic plane",
+        "snippet": "There exist various pseudospheres in Euclidean space that have a finite area of constant negative Gaussian curvature"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib construction of pseudospheres with finite area and constant negative Gaussian curvature.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Hilbert immersion theorem",
+      "anchor": {
+        "section": "Physical realizations of the hyperbolic plane",
+        "snippet": "one cannot isometrically immerse a complete hyperbolic plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of Hilbert's theorem on non-immersion of the complete hyperbolic plane in Euclidean 3-space.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Non-metric Euclidean models",
+      "anchor": {
+        "section": "Physical realizations of the hyperbolic plane",
+        "snippet": "Other useful models of hyperbolic geometry exist in Euclidean space, in which the metric is not preserved"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration classifying non-metric Euclidean models of hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Thurston paper model",
+      "anchor": {
+        "section": "Physical realizations of the hyperbolic plane",
+        "snippet": "A particularly well-known paper model based on the pseudosphere is due to William Thurston"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib example formalizing Thurston's paper model of the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Crochet hyperbolic plane",
+      "anchor": {
+        "section": "Physical realizations of the hyperbolic plane",
+        "snippet": "The art of crochet has been used to demonstrate hyperbolic planes"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of crocheted models of hyperbolic planes.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Hyperbolic soccerball",
+      "anchor": {
+        "section": "Physical realizations of the hyperbolic plane",
+        "snippet": "a quick-to-make paper model dubbed the \" hyperbolic soccerball \""
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib example of the paper model called the hyperbolic soccerball.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Hyperbolic quilt",
+      "anchor": {
+        "section": "Physical realizations of the hyperbolic plane",
+        "snippet": "a hyperbolic quilt, designed by Helaman Ferguson"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib example of Ferguson's hyperbolic quilt.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Pseudospheres",
+      "anchor": {
+        "section": "Models of the hyperbolic plane",
+        "snippet": "Various pseudospheres – surfaces with constant negative Gaussian curvature – can be embedded in 3-D space"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of pseudospheres as embedded surfaces of constant negative Gaussian curvature.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Tractoid model",
+      "anchor": {
+        "section": "Models of the hyperbolic plane",
+        "snippet": "using the tractoid as a model of the hyperbolic plane is analogous to using a cone or cylinder as a model of the Euclidean plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of the tractoid model of the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "No full Euclidean embedding",
+      "anchor": {
+        "section": "Models of the hyperbolic plane",
+        "snippet": "the entire hyperbolic plane cannot be embedded into Euclidean space in this way"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem forbidding a full Euclidean embedding of the entire hyperbolic plane in this sense.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Four common models",
+      "anchor": {
+        "section": "Models of the hyperbolic plane",
+        "snippet": "There are four models commonly used for hyperbolic geometry"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Basic",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines the upper-half-plane model and the complex unit disk, but I found no declaration listing the four common models.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Models define hyperbolic plane",
+      "anchor": {
+        "section": "Models of the hyperbolic plane",
+        "snippet": "These models define a hyperbolic plane which satisfies the axioms of a hyperbolic geometry"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem that the named models satisfy axioms of hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Models extend to higher dimensions",
+      "anchor": {
+        "section": "Models of the hyperbolic plane",
+        "snippet": "All these models are extendable to more dimensions"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem extending the hyperbolic plane models to higher-dimensional hyperbolic spaces.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Beltrami-Klein model names",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "The Beltrami–Klein model , also known as the projective disk model, Klein disk model and Klein model"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the Beltrami-Klein model or its alternative names.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Beltrami-Klein disk model",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "For the two dimensions this model uses the interior of the unit circle for the complete hyperbolic plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the Beltrami-Klein disk model as a hyperbolic-plane model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Beltrami-Klein lines",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "the chords of this circle are the hyperbolic lines"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration identifying Beltrami-Klein hyperbolic lines with disk chords.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Beltrami-Klein ball model",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "For higher dimensions this model uses the interior of the unit ball"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the higher-dimensional Beltrami-Klein ball model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Beltrami-Klein higher-dimensional lines",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "the chords of this n -ball are the hyperbolic lines"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration identifying higher-dimensional Beltrami-Klein lines with ball chords.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Beltrami-Klein straight lines",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "This model has the advantage that lines are straight"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem stating that lines are straight in the Beltrami-Klein model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Beltrami-Klein angle distortion",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "the disadvantage that angles are distorted"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about angle distortion in the Beltrami-Klein model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Beltrami-Klein circles not circles",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "circles are not represented as circles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about representation of circles in the Beltrami-Klein model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Beltrami-Klein distance",
+      "anchor": {
+        "section": "The Beltrami–Klein model",
+        "snippet": "The distance in this model is half the logarithm of the cross-ratio"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for Beltrami-Klein distance via logarithm of a cross-ratio.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Poincare disk model",
+      "anchor": {
+        "section": "The Poincaré disk model",
+        "snippet": "The Poincaré disk model , also known as the conformal disk model, also employs the interior of the unit circle"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Complex.UnitDisc",
+        "module": "Mathlib.Analysis.Complex.UnitDisc.Basic",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines the complex unit disk, but not the Poincare disk as a hyperbolic metric model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Poincare disk lines",
+      "anchor": {
+        "section": "The Poincaré disk model",
+        "snippet": "lines are represented by arcs of circles that are orthogonal to the boundary circle, plus diameters of the boundary circle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for Poincare-disk hyperbolic lines as orthogonal circle arcs and diameters.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Poincare disk conformal",
+      "anchor": {
+        "section": "The Poincaré disk model",
+        "snippet": "This model preserves angles, and is thereby conformal"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem proving conformality of the Poincare disk model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Poincare disk isometries",
+      "anchor": {
+        "section": "The Poincaré disk model",
+        "snippet": "All isometries within this model are therefore Möbius transformations"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem classifying Poincare-disk isometries as Mobius transformations.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Poincare disk circles",
+      "anchor": {
+        "section": "The Poincaré disk model",
+        "snippet": "Circles entirely within the disk remain circles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about hyperbolic circles remaining Euclidean circles in the Poincare disk model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Euclidean and hyperbolic circle centers differ",
+      "anchor": {
+        "section": "The Poincaré disk model",
+        "snippet": "the Euclidean center of the circle is closer to the center of the disk than is the hyperbolic center of the circle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem comparing Euclidean and hyperbolic centers of Poincare-disk circles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Poincare disk horocycles",
+      "anchor": {
+        "section": "The Poincaré disk model",
+        "snippet": "Horocycles are circles within the disk which are tangent to the boundary circle"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of Poincare-disk horocycles as boundary-tangent circles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Poincare disk hypercycles",
+      "anchor": {
+        "section": "The Poincaré disk model",
+        "snippet": "Hypercycles are open-ended chords and circular arcs within the disc that terminate on the boundary circle at non-orthogonal angles"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of Poincare-disk hypercycles as nonorthogonal boundary-terminating arcs.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Poincare half-plane model",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "The Poincaré half-plane model takes one-half of the Euclidean plane, bounded by a line B of the plane, to be a model of the hyperbolic plane"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Basic",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines the open complex upper half-plane and its hyperbolic metric, but not the full model statement with an arbitrary boundary line B.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Boundary line excluded",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "The line B is not included in the model"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "UpperHalfPlane.im_pos",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Basic",
+        "match_kind": "exact"
+      },
+      "note": "The condition 0 < z.im in UpperHalfPlane.im_pos excludes the real boundary line in the standard upper-half-plane realization.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Upper half-plane realization",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "the x-axis is taken as line B and the half plane is the upper half"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "UpperHalfPlane.upperHalfPlaneSet",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Basic",
+        "match_kind": "exact"
+      },
+      "note": "UpperHalfPlane.upperHalfPlaneSet is exactly the subset of complex numbers with positive imaginary part, i.e. the upper half-plane above the real axis.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Half-plane hyperbolic lines",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "Hyperbolic lines are then either half-circles orthogonal to B or rays perpendicular to B"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.gl_smul_eq_self_iff_dist_eq",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.FixedPoints",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib proves some fixed-point loci in the upper half-plane are vertical lines or half-circles, but it does not define hyperbolic lines this way.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Ray interval length",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "The length of an interval on a ray is given by logarithmic measure"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "UpperHalfPlane.dist_of_re_eq",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "exact"
+      },
+      "note": "UpperHalfPlane.dist_of_re_eq states that points on the same vertical line have distance equal to the distance between logarithms of their imaginary parts.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Ray length homothety invariance",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "it is invariant under a homothetic transformation"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "UpperHalfPlane.isometry_pos_mul",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Metric",
+        "match_kind": "exact"
+      },
+      "note": "UpperHalfPlane.isometry_pos_mul proves that positive real scaling is an isometry of the upper half-plane metric.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Half-plane conformal",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "this model preserves angles, and is thus conformal"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.contMDiff_coe",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Manifold",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib gives the upper half-plane a complex manifold structure, but I found no theorem proving conformality of the hyperbolic metric model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Half-plane isometries",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "All isometries within this model are therefore Möbius transformations of the plane"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.coe_smul",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib formalizes Mobius actions on the upper half-plane and proves key generators are isometries, but not that all half-plane isometries are Mobius transformations.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Half-plane as disk limit",
+      "anchor": {
+        "section": "The Poincaré half-plane model",
+        "snippet": "The half-plane model is the limit of the Poincaré disk model"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem deriving the half-plane model as a limit of the Poincare disk model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperboloid model",
+      "anchor": {
+        "section": "The hyperboloid model",
+        "snippet": "The hyperboloid model or Lorentz model employs a 2-dimensional hyperboloid of revolution"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the hyperboloid or Lorentz model of hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Hyperboloid model in relativity",
+      "anchor": {
+        "section": "The hyperboloid model",
+        "snippet": "This model has direct application to special relativity"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration connecting the hyperboloid model to special relativity.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Minkowski 3-space spacetime model",
+      "anchor": {
+        "section": "The hyperboloid model",
+        "snippet": "Minkowski 3-space is a model for spacetime"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of Minkowski 3-space as a spacetime model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperboloid as observer events",
+      "anchor": {
+        "section": "The hyperboloid model",
+        "snippet": "One can take the hyperboloid to represent the events"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration interpreting a hyperboloid as observer events.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic distance as rapidity",
+      "anchor": {
+        "section": "The hyperboloid model",
+        "snippet": "The hyperbolic distance between two points on the hyperboloid can then be identified with the relative rapidity between the two corresponding observers"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem identifying hyperboloid-model distance with relative rapidity.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperboloid model higher dimension",
+      "anchor": {
+        "section": "The hyperboloid model",
+        "snippet": "The model generalizes directly to an additional dimension"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem generalizing the hyperboloid model to higher dimensions.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hemisphere model role",
+      "anchor": {
+        "section": "The hemisphere model",
+        "snippet": "The hemisphere model is not often used as model by itself, but it functions as a useful tool for visualizing transformations between the other models"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the hemisphere model or its role in visualizing transformations.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hemisphere model domain",
+      "anchor": {
+        "section": "The hemisphere model",
+        "snippet": "The hemisphere model uses the upper half of the unit sphere"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the hemisphere model domain as the upper half of the unit sphere.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hemisphere hyperbolic lines",
+      "anchor": {
+        "section": "The hemisphere model",
+        "snippet": "The hyperbolic lines are half-circles orthogonal to the boundary of the hemisphere"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for hemisphere-model hyperbolic lines as boundary-orthogonal half-circles.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hemisphere projections yield models",
+      "anchor": {
+        "section": "The hemisphere model",
+        "snippet": "The hemisphere model is part of a Riemann sphere , and different projections give different models of the hyperbolic plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem deriving hyperbolic-plane models from projections of a hemisphere in the Riemann sphere.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "All models same structure",
+      "anchor": {
+        "section": "Connection between the models",
+        "snippet": "All models essentially describe the same structure"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem proving equivalence of all named models of the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Models as coordinate charts",
+      "anchor": {
+        "section": "Connection between the models",
+        "snippet": "they represent different coordinate charts laid down on the same metric space"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration identifying the common hyperbolic models as charts on one metric space.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Characteristic curvature of hyperbolic plane",
+      "anchor": {
+        "section": "Connection between the models",
+        "snippet": "The characteristic feature of the hyperbolic plane itself is that it has a constant negative Gaussian curvature"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the hyperbolic plane by constant negative Gaussian curvature.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Geodesic invariance",
+      "anchor": {
+        "section": "Connection between the models",
+        "snippet": "The geodesics are similarly invariant"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem proving invariance of hyperbolic geodesics across model transformations.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperbolic geometry via geodesics",
+      "anchor": {
+        "section": "Connection between the models",
+        "snippet": "Hyperbolic geometry is generally introduced in terms of the geodesics and their intersections on the hyperbolic plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of hyperbolic geometry in terms of geodesics and their intersections.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Non-isometric Euclidean embedding",
+      "anchor": {
+        "section": "Connection between the models",
+        "snippet": "we can always embed it in a Euclidean space of same dimension, but the embedding is clearly not isometric"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about non-isometric Euclidean embeddings of hyperbolic space in the same dimension.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Infinitely many charts",
+      "anchor": {
+        "section": "Connection between the models",
+        "snippet": "The hyperbolic space can be represented by infinitely many different charts"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem that hyperbolic space has infinitely many different model charts.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Model transformations",
+      "anchor": {
+        "section": "Connection between the models",
+        "snippet": "Since the four models describe the same metric space, each can be transformed into the other"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem giving transformations between the four common hyperbolic plane models.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Gans model",
+      "anchor": {
+        "section": "The Gans model",
+        "snippet": "David Gans proposed a flattened hyperboloid model"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the Gans flattened hyperboloid model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Gans model as projection",
+      "anchor": {
+        "section": "The Gans model",
+        "snippet": "It is an orthographic projection of the hyperboloid model onto the xy-plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem identifying the Gans model as an orthographic projection of the hyperboloid model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Gans model uses entire plane",
+      "anchor": {
+        "section": "The Gans model",
+        "snippet": "this model utilizes the entire Euclidean plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem that the Gans model uses the entire Euclidean plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Gans model lines",
+      "anchor": {
+        "section": "The Gans model",
+        "snippet": "The lines in this model are represented as branches of a hyperbola"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration representing Gans-model hyperbolic lines as branches of hyperbolas.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Conformal square model",
+      "anchor": {
+        "section": "The conformal square model",
+        "snippet": "The conformal square model of the hyperbolic plane arises from using Schwarz–Christoffel mapping to convert the Poincaré disk into a square"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the conformal square model via a Schwarz-Christoffel map.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Conformal square finite extent",
+      "anchor": {
+        "section": "The conformal square model",
+        "snippet": "This model has finite extent, like the Poincaré disk"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about finite extent of the conformal square model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Conformal square points inside square",
+      "anchor": {
+        "section": "The conformal square model",
+        "snippet": "all of the points are inside a square"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration that conformal-square-model points lie inside a square.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Conformal square conformal",
+      "anchor": {
+        "section": "The conformal square model",
+        "snippet": "This model is conformal"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem proving conformality of the conformal square model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Band model",
+      "anchor": {
+        "section": "The band model",
+        "snippet": "The band model employs a portion of the Euclidean plane between two parallel lines"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of the band model of the hyperbolic plane.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Band model preserved distance line",
+      "anchor": {
+        "section": "The band model",
+        "snippet": "Distance is preserved along one line through the middle of the band"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about distance preservation along the middle line of the band model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Band model metric",
+      "anchor": {
+        "section": "The band model",
+        "snippet": "the metric is given by"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for the band-model metric formula.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Isometry reflection decomposition",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "Every isometry ( transformation or motion ) of the hyperbolic plane to itself can be realized as the composition of at most three reflections"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "EuclideanGeometry.reflection",
+        "module": "Mathlib.Geometry.Euclidean.Projection",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib has Euclidean reflection infrastructure, but I found no theorem decomposing hyperbolic-plane isometries into at most three reflections.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "Higher-dimensional reflection decomposition",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "In n -dimensional hyperbolic space, up to n +1 reflections might be required"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem giving the n+1 reflection bound for hyperbolic n-space isometries.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Isometry classification",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "All isometries of the hyperbolic plane can be classified into these classes"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Matrix.IsParabolic",
+        "module": "Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.FinTwo",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib classifies 2 by 2 matrices into parabolic, hyperbolic, and elliptic cases for upper-half-plane actions, but not the article's full isometry list.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Identity isometry",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "the identity isometry – nothing moves"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.glScalar_smul",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction",
+        "match_kind": "special_case"
+      },
+      "note": "UpperHalfPlane.glScalar_smul proves scalar GL matrices act trivially on the upper half-plane, but it is not the full named identity-isometry classification item.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Inversion through a point",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "inversion through a point (half turn) – two reflections through mutually perpendicular lines passing through the given point"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of hyperbolic inversion through a point as a half-turn from two reflections.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Rotation around a normal point",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "rotation around a normal point – two reflections through lines passing through the given point"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.fixedPt",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.FixedPoints",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines the unique fixed point of an elliptic orientation-preserving upper-half-plane action, but not rotations as products of two reflections.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Horolation",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "\"rotation\" around an ideal point (horolation) – two reflections through lines leading to the ideal point"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of horolation or ideal-point rotations in hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Translation along a line",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "translation along a straight line – two reflections through lines perpendicular to the given line"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.modular_T_zpow_smul",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib proves the modular T powers act as real translations on the upper half-plane, but not the reflection decomposition of hyperbolic translations along a line.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Reflection through a line",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "reflection through a line – one reflection"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.exists_gl_smul_eq_self_iff_trace_eq_zero",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.FixedPoints",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib characterizes fixed-point loci of orientation-reversing upper-half-plane actions, but does not define reflection through a hyperbolic line as an isometry class.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Glide reflection",
+      "anchor": {
+        "section": "Isometries of the hyperbolic plane",
+        "snippet": "combined reflection through a line and translation along the same line"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of glide reflections in hyperbolic geometry.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Escher conformal disk model",
+      "anchor": {
+        "section": "In art",
+        "snippet": "Circle Limit III and Circle Limit IV illustrate the conformal disc model"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib example formalizing Escher's Circle Limit works as illustrations of the conformal disk model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Circle Limit III white lines are hypercycles",
+      "anchor": {
+        "section": "In art",
+        "snippet": "The white lines in III are not quite geodesics (they are hypercycles )"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about the curves in Circle Limit III being hypercycles rather than geodesics.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Negative curvature visible by angle sums",
+      "anchor": {
+        "section": "In art",
+        "snippet": "It is also possible to see the negative curvature of the hyperbolic plane, through its effect on the sum of angles in triangles and squares"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem connecting visual angle sums in such tilings with negative curvature.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Circle Limit III vertex angles",
+      "anchor": {
+        "section": "In art",
+        "snippet": "in Circle Limit III every vertex belongs to three triangles and three squares"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of the combinatorics of Escher's Circle Limit III vertices.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Euclidean comparison angle sum",
+      "anchor": {
+        "section": "In art",
+        "snippet": "In the Euclidean plane, their angles would sum to 450°"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration formalizing this specific 450 degree comparison for the Escher tiling vertex.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Triangle angle sum from Escher tiling",
+      "anchor": {
+        "section": "In art",
+        "snippet": "the sum of angles of a triangle in the hyperbolic plane must be smaller than 180°"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib derivation of the hyperbolic triangle angle-sum bound from Escher tiling data.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Exponential growth",
+      "anchor": {
+        "section": "In art",
+        "snippet": "Another visible property is exponential growth"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem stating exponential growth for the hyperbolic plane in this context.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Fish count grows exponentially",
+      "anchor": {
+        "section": "In art",
+        "snippet": "the number of fishes within a distance of n from the center rises exponentially"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of exponential fish-count growth in Escher's tiling.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Ball area grows exponentially",
+      "anchor": {
+        "section": "In art",
+        "snippet": "the area of a ball of radius n must rise exponentially in n"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.volume_eq_lintegral",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.Measure",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines hyperbolic volume on the upper half-plane, but I found no theorem proving exponential ball-area growth.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Crocheted hyperbolic planes",
+      "anchor": {
+        "section": "In art",
+        "snippet": "The art of crochet has been used to demonstrate hyperbolic planes"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib example formalizing crocheted demonstrations of hyperbolic planes.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "HyperRogue hyperbolic tilings",
+      "anchor": {
+        "section": "In art",
+        "snippet": "HyperRogue is a roguelike game set on various tilings of the hyperbolic plane"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib formalization of HyperRogue or its hyperbolic tilings.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Hyperbolic geometry in all dimensions",
+      "anchor": {
+        "section": "Higher dimensions",
+        "snippet": "a hyperbolic geometry exists for every higher number of dimensions"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib family of hyperbolic geometries or hyperbolic spaces in all dimensions.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperbolic space as symmetric space",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "Hyperbolic space of dimension n is a special case of a Riemannian symmetric space of noncompact type"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib definition of hyperbolic n-space as a Riemannian symmetric space of noncompact type.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Hyperbolic space quotient",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "as it is isomorphic to the quotient"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration identifying hyperbolic space with the relevant orthogonal-group quotient.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Orthogonal group action on Minkowski space",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "The orthogonal group O(1, n ) acts by norm-preserving transformations on Minkowski space R 1, n"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for O(1,n) acting on Minkowski space R^(1,n).",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Orthogonal group transitive action",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "it acts transitively on the two-sheet hyperboloid of norm 1 vectors"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for transitivity of O(1,n) on the two-sheet unit hyperboloid.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Timelike lines meet antipodal hyperboloid points",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "Timelike lines (i.e., those with positive-norm tangents) through the origin pass through antipodal points in the hyperboloid"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about timelike lines through the origin meeting antipodal hyperboloid points.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Line-space model of hyperbolic n-space",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "the space of such lines yields a model of hyperbolic n -space"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib construction of hyperbolic n-space as a space of timelike lines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Stabilizer of a line",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "The stabilizer of any particular line is isomorphic to the product of the orthogonal groups O( n ) and O(1)"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem identifying a timelike-line stabilizer with O(n) x O(1).",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Linear-algebraic hyperbolic concepts",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "Many of the elementary concepts in hyperbolic geometry can be described in linear algebraic terms"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib development giving elementary hyperbolic concepts in this linear-algebraic homogeneous model.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Geodesic paths as intersections",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "geodesic paths are described by intersections with planes through the origin"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration describing hyperboloid-model geodesics as plane intersections.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Dihedral angles by inner products",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "dihedral angles between hyperplanes can be described by inner products of normal vectors"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration for hyperbolic dihedral angles via Minkowski inner products of normal vectors.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Reflection groups by matrices",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "hyperbolic reflection groups can be given explicit matrix realizations"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Module.reflection",
+        "module": "Mathlib.LinearAlgebra.Reflection",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib has general linear reflection infrastructure, but I found no hyperbolic reflection groups realized by explicit matrices.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Small-dimensional exceptional isomorphisms",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "In small dimensions, there are exceptional isomorphisms of Lie groups that yield additional ways to consider symmetries of hyperbolic spaces"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem formalizing these exceptional Lie-group isomorphisms for hyperbolic-space symmetries.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Dimension two Lie group isomorphisms",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "in dimension 2, the isomorphisms SO + (1, 2) ≅ PSL(2, R ) ≅ PSU(1, 1) allow one to interpret the upper half plane model as the quotient SL(2, R )/SO(2) and the Poincaré disc model as the quotient SU(1, 1)/U(1)"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem for SO+(1,2), PSL(2,R), and PSU(1,1) isomorphisms or the stated quotient models.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Symmetry groups act fractionally linearly",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "the symmetry groups act by fractional linear transformations"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "UpperHalfPlane.coe_smul",
+        "module": "Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction",
+        "match_kind": "invocation"
+      },
+      "note": "UpperHalfPlane.coe_smul gives the fractional-linear formula for the GL(2,R) action on the upper half-plane, but not the full symmetry-group statement across models.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "Cayley transformation conjugates symmetry groups",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "The Cayley transformation not only takes one model of the hyperbolic plane to the other, but realizes the isomorphism of symmetry groups as conjugation in a larger group"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem about the Cayley transform conjugating hyperbolic-plane symmetry groups.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Dimension three boundary action",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "In dimension 3, the fractional linear action of PGL(2, C ) on the Riemann sphere is identified with the action on the conformal boundary of hyperbolic 3-space"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib theorem identifying the PGL(2,C) Riemann-sphere action with the conformal boundary action of hyperbolic 3-space.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "Studying hyperbolic 3-isometries by matrices",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "This allows one to study isometries of hyperbolic 3-space by considering spectral properties of representative complex matrices"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib development of hyperbolic 3-space isometries via spectra of complex matrices.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Parabolic transformations",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "parabolic transformations are conjugate to rigid translations in the upper half-space model"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Matrix.GeneralLinearGroup.IsParabolic",
+        "module": "Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.FinTwo",
+        "match_kind": "invocation"
+      },
+      "note": "Mathlib defines parabolic GL(2) elements and related upper-triangular characterizations, but I found no theorem stating conjugacy to rigid translations in upper half-space.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "Unipotent triangular representatives",
+      "anchor": {
+        "section": "Homogeneous structure",
+        "snippet": "they are exactly those transformations that can be represented by unipotent upper triangular matrices"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Matrix.GeneralLinearGroup.isParabolic_iff_of_upperTriangular_of_det",
+        "module": "Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.FinTwo",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib proves a determinant ±1 upper-triangular parabolic iff it is represented by upperRightHom or its negative, a special case of the unipotent triangular representative claim.",
+      "provenance": "ai"
+    }
+  ]
+}

--- a/site/annotations/Nonlinear_programming.json
+++ b/site/annotations/Nonlinear_programming.json
@@ -1,0 +1,551 @@
+{
+  "slug": "Nonlinear_programming",
+  "wikipedia_title": "Nonlinear programming",
+  "display_title": "Nonlinear programming",
+  "schema_version": 3,
+  "annotation_style": "theorem_article",
+  "annotations": [
+    {
+      "kind": "definition",
+      "label": "nonlinear programming",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "nonlinear programming ( NLP ), also known as nonlinear optimization"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ defines nonlinear programming or nonlinear optimization as a mathematical object.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "optimization problem",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "An optimization problem is one of calculation of the extrema"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsExtrOn",
+        "module": "Mathlib.Order.Filter.Extr",
+        "match_kind": "generalization"
+      },
+      "note": "IsExtrOn formalizes a point being a minimum or maximum of a function on a set, but Mathlib has no OptimizationProblem structure or calculation problem declaration.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "nonlinear programming subfield",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "It is the sub-field of mathematical optimization"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes subject-area containment such as nonlinear programming being a subfield of mathematical optimization.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "nonlinear programming problem setup",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "Let n , m , and p be positive integers."
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ packages an NLP datum with positive integers n, m, p and associated objective and constraint maps.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "nonlinear programming problem form",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "A nonlinear programming problem is an optimization problem of the form"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsMinOn",
+        "module": "Mathlib.Order.Filter.Extr",
+        "match_kind": "generalization"
+      },
+      "note": "IsMinOn formalizes minimizing an objective over an arbitrary feasible set, but Mathlib has no nonlinear-program form with equality and inequality constraints.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "feasible problem",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "feasible problem is one for which there exists at least one set of values"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Set.Nonempty",
+        "module": "Mathlib.Data.Set.Defs",
+        "match_kind": "generalization"
+      },
+      "note": "Set.Nonempty exactly expresses existence of a feasible point once constraints are encoded as a set, but Mathlib has no FeasibleProblem declaration.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "infeasible problem",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "an infeasible problem is one for which no set of values"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Set.not_nonempty_iff_eq_empty",
+        "module": "Mathlib.Data.Set.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Set.not_nonempty_iff_eq_empty identifies no feasible point with an empty feasible set, but Mathlib has no infeasible-problem declaration.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "infeasible constraints are contradictory",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "the constraints are mutually contradictory, and no solution exists"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Set.not_nonempty_iff_eq_empty",
+        "module": "Mathlib.Data.Set.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "Set.not_nonempty_iff_eq_empty formalizes the no-solution part as emptiness of the feasible set, but it does not define mutually contradictory NLP constraints.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "unbounded problem",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "unbounded problem is a feasible problem for which the objective function"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "BddBelow",
+        "module": "Mathlib.Order.Bounds.Defs",
+        "match_kind": "generalization"
+      },
+      "note": "BddBelow formalizes bounded-below objective images, but Mathlib has no declaration for unbounded optimization problems.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "unbounded problem has no optimum",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "there is no optimal solution"
+      },
+      "status": "formalized",
+      "mathlib": {
+        "decl": "IsMinOn.bddBelow",
+        "module": "Mathlib.Order.Filter.Extr",
+        "match_kind": "generalization"
+      },
+      "note": "For minimization, IsMinOn.bddBelow gives the contrapositive that an objective image unbounded below cannot have an optimum.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "feasibility violation handling",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "infeasible problems are handled by minimizing a sum of feasibility violations"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes handling infeasible NLPs by minimizing a sum of feasibility violations.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "convex nonlinear program",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "then the program is called convex"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "ConvexOn",
+        "module": "Mathlib.Analysis.Convex.Function",
+        "match_kind": "generalization"
+      },
+      "note": "ConvexOn formalizes convex objective functions on convex sets, but Mathlib has no full convex nonlinear program definition with constraints.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "convex optimization methods apply",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "general methods from convex optimization can be used in most cases"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsMinOn.of_isLocalMinOn_of_convexOn",
+        "module": "Mathlib.Analysis.Convex.Extrema",
+        "match_kind": "generalization"
+      },
+      "note": "IsMinOn.of_isLocalMinOn_of_convexOn captures a key convex-optimization consequence, but Mathlib does not formalize the meta-claim that convex methods apply.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "quadratic programming case",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "If the objective function is quadratic and the constraints are linear"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "QuadraticMap",
+        "module": "Mathlib.LinearAlgebra.QuadraticForm.Basic",
+        "match_kind": "generalization"
+      },
+      "note": "QuadraticMap formalizes quadratic maps, but Mathlib has no quadratic programming case definition with linear constraints.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "fractional programming transformation",
+      "anchor": {
+        "section": "Definition and discussion",
+        "snippet": "then the problem can be transformed to a convex optimization problem"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes fractional programming or its transformation to a convex optimization problem.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "transportation cost optimization",
+      "anchor": {
+        "section": "Applicability",
+        "snippet": "A typical non- convex problem is that of optimizing transportation costs"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes transportation cost optimization as a nonlinear programming example.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "petroleum product transport",
+      "anchor": {
+        "section": "Applicability",
+        "snippet": "An example would be petroleum product transport"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes petroleum product transport as an optimization example.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "batch size discontinuities",
+      "anchor": {
+        "section": "Applicability",
+        "snippet": "the cost functions may have discontinuities"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ states that batch-size transportation cost functions may be discontinuous.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "linear data analysis example",
+      "anchor": {
+        "section": "Applicability",
+        "snippet": "some simple data analysis"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes the article's simple linear data analysis example.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "data fitting is generally nonlinear",
+      "anchor": {
+        "section": "Applicability",
+        "snippet": "in general these problems are also nonlinear"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ states that data-fitting problems are generally nonlinear.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "numerical best fit",
+      "anchor": {
+        "section": "Applicability",
+        "snippet": "One tries to find a best fit numerically."
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Function.argminOn",
+        "module": "Mathlib.Order.WellFounded",
+        "match_kind": "generalization"
+      },
+      "note": "Function.argminOn selects an exact minimizer on a nonempty set under a well-founded order, but Mathlib has no numerical best-fit procedure.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "KKT necessary conditions",
+      "anchor": {
+        "section": "Analytic methods",
+        "snippet": "the Karush–Kuhn–Tucker (KKT) conditions provide necessary conditions"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsLocalExtrOn.exists_multipliers_of_hasStrictFDerivAt",
+        "module": "Mathlib.Analysis.Calculus.LagrangeMultipliers",
+        "match_kind": "special_case"
+      },
+      "note": "IsLocalExtrOn.exists_multipliers_of_hasStrictFDerivAt gives equality-constrained Lagrange multiplier necessary conditions, which are only a special case of full KKT inequality and complementarity conditions.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "subdifferential KKT conditions",
+      "anchor": {
+        "section": "Analytic methods",
+        "snippet": "subdifferential versions of Karush–Kuhn–Tucker (KKT) conditions are available"
+      },
+      "status": "not_formalized",
+      "note": "Searches found no subdifferential, subgradient, or subdifferential KKT declarations in Mathlib/.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "KKT sufficient under convexity",
+      "anchor": {
+        "section": "Analytic methods",
+        "snippet": "the KKT conditions are sufficient for a global optimum"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "IsMinOn.of_isLocalMinOn_of_convexOn",
+        "module": "Mathlib.Analysis.Convex.Extrema",
+        "match_kind": "generalization"
+      },
+      "note": "IsMinOn.of_isLocalMinOn_of_convexOn proves a convex local minimum is global, but no declaration states KKT conditions are sufficient under convexity.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "KKT local sufficiency without convexity",
+      "anchor": {
+        "section": "Analytic methods",
+        "snippet": "these conditions are sufficient only for a local optimum"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ establishes KKT local sufficiency without convexity.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "finite local optima can be enumerated",
+      "anchor": {
+        "section": "Analytic methods",
+        "snippet": "one can find all of them analytically"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ states that finitely many local optima can be analytically enumerated.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "iterative numerical methods",
+      "anchor": {
+        "section": "Numeric methods",
+        "snippet": "These methods are iterative"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ defines nonlinear programming numerical methods as iterative procedures.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "zero-order routines",
+      "anchor": {
+        "section": "Numeric methods",
+        "snippet": "Zero-order routines - use only the values"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ defines zero-order optimization routines that use only objective values.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "first-order routines",
+      "anchor": {
+        "section": "Numeric methods",
+        "snippet": "First-order routines - use also the values"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "HasFDerivAt",
+        "module": "Mathlib.Analysis.Calculus.FDeriv.Defs",
+        "match_kind": "generalization"
+      },
+      "note": "HasFDerivAt formalizes first derivatives of functions, but Mathlib has no declaration classifying first-order numerical routines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "second-order routines",
+      "anchor": {
+        "section": "Numeric methods",
+        "snippet": "Second-order routines - use also the values"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "iteratedFDeriv",
+        "module": "Mathlib.Analysis.Calculus.ContDiff.FTaylorSeries",
+        "match_kind": "generalization"
+      },
+      "note": "iteratedFDeriv formalizes arbitrary-order derivatives, including second derivatives, but Mathlib has no declaration classifying second-order numerical routines.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "higher-order routines not used",
+      "anchor": {
+        "section": "Numeric methods",
+        "snippet": "Third-order routines (and higher) are theoretically possible"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "iteratedFDeriv",
+        "module": "Mathlib.Analysis.Calculus.ContDiff.FTaylorSeries",
+        "match_kind": "generalization"
+      },
+      "note": "iteratedFDeriv supplies higher derivatives in principle, but no declaration states that higher-order optimization routines are unused in practice.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "branch and bound method",
+      "anchor": {
+        "section": "Branch and bound",
+        "snippet": "Another method involves the use of branch and bound techniques"
+      },
+      "status": "not_formalized",
+      "note": "No branch-and-bound method declaration was found in Mathlib/.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "theorem",
+      "label": "branch and bound optimality certificate",
+      "anchor": {
+        "section": "Branch and bound",
+        "snippet": "This solution is optimal, although possibly not unique."
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes a branch-and-bound optimality certificate.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "ε-optimal point",
+      "anchor": {
+        "section": "Branch and bound",
+        "snippet": "such points are called ε-optimal"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ defines ε-optimal points for optimization problems.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "ε-optimal termination",
+      "anchor": {
+        "section": "Branch and bound",
+        "snippet": "Terminating to ε-optimal points is typically necessary"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ states that branch-and-bound termination to ε-optimal points is necessary.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "ALGLIB nonlinear programming solver",
+      "anchor": {
+        "section": "Implementations",
+        "snippet": "ALGLIB (C++, C#, Java, Python API) implements several first-order and derivative-free nonlinear programming solvers"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ records ALGLIB or its nonlinear programming solvers.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "NLopt nonlinear programming solver",
+      "anchor": {
+        "section": "Implementations",
+        "snippet": "NLopt (C/C++ implementation, with numerous interfaces including Julia, Python, R, MATLAB/Octave), includes various nonlinear programming solvers"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ records NLopt or its nonlinear programming solvers.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "SciPy nonlinear programming solver",
+      "anchor": {
+        "section": "Implementations",
+        "snippet": "SciPy (de facto standard for scientific Python) has scipy.optimize solver"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ records SciPy or scipy.optimize as a nonlinear programming solver.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "IPOPT nonlinear programming solver",
+      "anchor": {
+        "section": "Implementations",
+        "snippet": "IPOPT (C++ implementation, with numerous interfaces including C, Fortran, Java, AMPL, R, Python, etc.) is an interior point method solver"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ records IPOPT or its interior-point nonlinear programming solver role.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "SNOPT proprietary solver",
+      "anchor": {
+        "section": "Implementations",
+        "snippet": "Proprietary solvers include SNOPT"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ records SNOPT as a proprietary nonlinear programming solver.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "2-dimensional nonlinear programming problem",
+      "anchor": {
+        "section": "2-dimensional example",
+        "snippet": "A simple problem (shown in the diagram) can be defined by the constraints"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes the article's specific two-dimensional nonlinear programming example.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "example",
+      "label": "3-dimensional nonlinear programming problem",
+      "anchor": {
+        "section": "3-dimensional example",
+        "snippet": "Another simple problem (see diagram) can be defined by the constraints"
+      },
+      "status": "not_formalized",
+      "note": "No declaration in Mathlib/ formalizes the article's specific three-dimensional nonlinear programming example.",
+      "provenance": "ai"
+    }
+  ]
+}

--- a/site/annotations/Quadratic_sieve.json
+++ b/site/annotations/Quadratic_sieve.json
@@ -1,0 +1,79 @@
+{
+  "slug": "Quadratic_sieve",
+  "wikipedia_title": "Quadratic sieve",
+  "display_title": "Quadratic sieve",
+  "schema_version": 3,
+  "annotation_style": "theorem_article",
+  "annotations": [
+    {
+      "kind": "definition",
+      "label": "Quadratic sieve",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "The quadratic sieve algorithm ( QS ) is an integer factorization algorithm"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Nat.factorization",
+        "module": "Mathlib.Data.Nat.Factorization.Defs",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib has `Nat.factorization` for prime factorizations of natural numbers, but I found no declaration defining the quadratic sieve algorithm or proving its correctness as a factorization algorithm.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "QS practical speed",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "in practice, the second-fastest method known"
+      },
+      "status": "not_formalized",
+      "note": "I found no Mathlib declaration about quadratic-sieve performance or comparative practical speed among factorization methods.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "QS under 100 digits",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "It is still the fastest for integers under 100 decimal digits"
+      },
+      "status": "not_formalized",
+      "note": "I found no declaration combining the quadratic sieve with a 100-decimal-digit threshold or a fastest-factorization claim.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "definition",
+      "label": "General-purpose factorization algorithm",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "It is a general-purpose factorization algorithm"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "Nat.factorization",
+        "module": "Mathlib.Data.Nat.Factorization.Defs",
+        "match_kind": "special_case"
+      },
+      "note": "Mathlib formalizes natural-number prime factorization via `Nat.factorization`, but I found no declaration classifying algorithms as general-purpose factorization algorithms.",
+      "provenance": "ai"
+    },
+    {
+      "kind": "proposition",
+      "label": "General-purpose running time dependence",
+      "anchor": {
+        "section": "(Lead)",
+        "snippet": "its running time depends solely on the size of the integer to be factored"
+      },
+      "status": "partial",
+      "mathlib": {
+        "decl": "AkraBazziRecurrence",
+        "module": "Mathlib.Computability.AkraBazzi.SumTransform",
+        "match_kind": "generalization"
+      },
+      "note": "`AkraBazziRecurrence` models some running-time recurrences as functions of a natural-number size parameter, but I found no factorization-specific general-purpose dependence criterion.",
+      "provenance": "ai"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Introduce a dedicated brain queue to track Wikidata-related work and publication state.
- Update the bot pipeline, refresh tooling, and workflow wiring to consume and publish queue items deterministically.
- Refresh affected annotation fixtures and add the queue UI page in the wiki app.

## Testing
- Not run (not requested)
- Reviewed the updated workflow, bot, and queue code paths for consistency with the new queue state model