### PR TITLE
site: fix review security and consistency findings

### DIFF
--- a/wiki/assets/editor.js
+++ b/wiki/assets/editor.js
@@ -226,24 +226,24 @@
     // Each click opens the next hidden annotation in the editor panel,
     // cycling through all of them (fix #2).
     let hiddenCursor = 0;
-    bar.querySelector("#wlr-hidden").addEventListener("click", function () {
-      openEditor(rejectedIdxs[hiddenCursor % rejectedIdxs.length]);
+    bar.querySelector("#wlr-hidden").addEventListener("click", function (e) {
+      openEditor(rejectedIdxs[hiddenCursor % rejectedIdxs.length], e.currentTarget);
       hiddenCursor++;
     });
   }
   if (suppressedIdxs.length) {
     // Same cycling pattern for overlap-suppressed annotations.
     let suppressedCursor = 0;
-    bar.querySelector("#wlr-suppressed").addEventListener("click", function () {
-      openEditor(suppressedIdxs[suppressedCursor % suppressedIdxs.length]);
+    bar.querySelector("#wlr-suppressed").addEventListener("click", function (e) {
+      openEditor(suppressedIdxs[suppressedCursor % suppressedIdxs.length], e.currentTarget);
       suppressedCursor++;
     });
   }
   if (orphanIdxs.length) {
     // Same cycling pattern for orphaned (anchor-rot) annotations.
     let orphanCursor = 0;
-    bar.querySelector("#wlr-orphans").addEventListener("click", function () {
-      openEditor(orphanIdxs[orphanCursor % orphanIdxs.length]);
+    bar.querySelector("#wlr-orphans").addEventListener("click", function (e) {
+      openEditor(orphanIdxs[orphanCursor % orphanIdxs.length], e.currentTarget);
       orphanCursor++;
     });
   }
@@ -358,6 +358,79 @@
 
   const $ = (id) => document.getElementById(id);
 
+  // Dialog focus lifecycle. Capture the launch point before focus moves into
+  // the panel, keep it stable while the panel is open, and restore it after a
+  // confirmed close. Picker rows and the hidden FAB are deliberately excluded:
+  // both are ephemeral launch controls, so their annotation/article target is
+  // passed explicitly by those call sites instead.
+  let dialogOpener = null;
+  let dialogFallback = null;
+  function isStableFocusTarget(el) {
+    return el instanceof HTMLElement && el.isConnected && !panel.contains(el) &&
+      !el.closest("#wlr-picker") && el !== fab && !el.closest("#wlr-intro");
+  }
+  function defaultDialogFallback() {
+    return bar.querySelector("button:not([disabled]),a[href]") ||
+      document.querySelector(".wl-article-body");
+  }
+  function rememberDialogOpener(preferred, fallback) {
+    // Opening another annotation while the dialog is already open must not
+    // replace the original launch point with the currently focused form field.
+    if (panel.classList.contains("open")) return;
+    const active = document.activeElement;
+    dialogOpener = isStableFocusTarget(preferred)
+      ? preferred
+      : isStableFocusTarget(active)
+        ? active
+        : null;
+    dialogFallback = isStableFocusTarget(fallback) ? fallback : defaultDialogFallback();
+  }
+  function focusProgrammatically(el) {
+    if (!isStableFocusTarget(el)) return false;
+    if (!el.matches("a[href],button,input,select,textarea,[tabindex]")) {
+      el.setAttribute("tabindex", "-1");
+    }
+    try {
+      el.focus({ preventScroll: true });
+    } catch (_) {
+      el.focus();
+    }
+    return true;
+  }
+  function restoreDialogFocus() {
+    const target = isStableFocusTarget(dialogOpener) ? dialogOpener : dialogFallback;
+    dialogOpener = null;
+    dialogFallback = null;
+    focusProgrammatically(target);
+  }
+  function focusableDialogControls() {
+    const selector = 'a[href],button,input,select,textarea,[tabindex]:not([tabindex="-1"])';
+    return Array.from(panel.querySelectorAll(selector)).filter((el) => {
+      if (el.disabled || el.hidden || el.getAttribute("aria-hidden") === "true") return false;
+      const style = window.getComputedStyle(el);
+      return style.display !== "none" && style.visibility !== "hidden" && el.getClientRects().length > 0;
+    });
+  }
+  function trapDialogTab(e) {
+    const controls = focusableDialogControls();
+    if (!controls.length) {
+      e.preventDefault();
+      panel.setAttribute("tabindex", "-1");
+      panel.focus();
+      return;
+    }
+    const first = controls[0];
+    const last = controls[controls.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey && (active === first || !panel.contains(active))) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && (active === last || !panel.contains(active))) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
   document.querySelectorAll(".anno").forEach((el) => {
     el.addEventListener("click", (e) => {
       const sel = window.getSelection();
@@ -390,7 +463,7 @@
       document.querySelectorAll(".anno.wlr-selected").forEach((n) => n.classList.remove("wlr-selected"));
       el.classList.add("wlr-selected");
       if (idxs.length === 1) {
-        maybeShowIntro(() => openEditor(idxs[0]));
+        maybeShowIntro(() => openEditor(idxs[0], el));
       } else {
         maybeShowIntro(() => showPicker(el, idxs));
       }
@@ -740,7 +813,9 @@
       row.addEventListener("click", (ev) => {
         ev.stopPropagation();
         dismissPicker();
-        openEditor(i);
+        // The row is removed before the dialog opens, so return focus to the
+        // stable annotation element rather than this ephemeral picker button.
+        openEditor(i, annoEl);
       });
       pickerEl.appendChild(row);
     });
@@ -757,6 +832,8 @@
     if (e.key === "Escape") {
       dismissPicker();
       if (panel.classList.contains("open")) requestClose();
+    } else if (e.key === "Tab" && panel.classList.contains("open")) {
+      trapDialogTab(e);
     } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && panel.classList.contains("open")) {
       // Cmd/Ctrl+Enter saves, matching the Save button.
       e.preventDefault();
@@ -835,7 +912,9 @@
   fab.addEventListener("click", () => {
     if (!pendingSel) return;
     fab.style.display = "none";
-    openAdder(pendingSel.text, pendingSel.section);
+    // The FAB is hidden as the dialog opens; the article body is the stable,
+    // relevant return point for an annotation created from a text selection.
+    openAdder(pendingSel.text, pendingSel.section, articleBody);
   });
 
   function mathlib(a) {
@@ -946,7 +1025,8 @@
     });
   }
 
-  function openEditor(idx) {
+  function openEditor(idx, opener) {
+    rememberDialogOpener(opener);
     editingIndex = idx;
     const a = annos[idx];
     const m = mathlib(a);
@@ -993,7 +1073,8 @@
     $("wlr-f-status").focus();
   }
 
-  function openAdder(text, section) {
+  function openAdder(text, section, opener) {
+    rememberDialogOpener(opener);
     editingIndex = null;
     panel.dataset.newSnippet = text;
     panel.dataset.newSection = section;
@@ -1038,6 +1119,7 @@
     delete panel.dataset.reanchor;
     document.querySelectorAll(".anno.wlr-selected").forEach((n) => n.classList.remove("wlr-selected"));
     $("wlr-status-msg").textContent = "";
+    restoreDialogFocus();
   }
   // Escape/× with unsaved changes ask before discarding (fix #11c).
   function requestClose() {

--- a/wiki/src/auth.ts
+++ b/wiki/src/auth.ts
@@ -27,6 +27,27 @@ const DEV_COOKIE = "wl_dev_user";
 const PIPELINE_USER_ID = "pipeline";
 type Ctx = Context<{ Bindings: Env }>;
 
+const CONTROL_CHAR_RE = /[\u0000-\u001f\u007f-\u009f]/;
+
+// Only permit same-origin browser navigation targets. A single leading slash
+// distinguishes local paths from protocol-relative URLs such as //evil.test.
+export function internalReturnPath(value: string | null | undefined, fallback: string): string {
+  if (!value || value[0] !== "/" || value[1] === "/" || value.includes("\\") || CONTROL_CHAR_RE.test(value)) {
+    return fallback;
+  }
+  return value;
+}
+
+// JSON alone is not safe in an inline script: the HTML parser recognizes
+// </script> before JavaScript parses the string. Escape that delimiter starter
+// and the two JavaScript line separators that are unsafe in older engines.
+export function scriptSafeJson(value: string): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 // Per-request better-auth instance (Workers bindings are only available per request).
 export function makeAuth(env: Env) {
   const db = drizzle(env.DB);
@@ -164,7 +185,7 @@ h1{font-size:1.2rem;margin:0 0 6px}p{color:#5f594e;font-size:.9rem;margin:0 0 18
 ${buttons || "<p>No login providers are configured.</p>"}
 <p style="margin-top:16px"><a href="${htmlEscape(returnTo, true)}">← back</a></p></div>
 <script>
-var ret=${JSON.stringify(returnTo)};
+var ret=${scriptSafeJson(returnTo)};
 document.querySelectorAll(".prov").forEach(function(b){b.addEventListener("click",function(){
   b.disabled=true;b.textContent="redirecting…";
   fetch("/api/auth/sign-in/social",{method:"POST",headers:{"Content-Type":"application/json"},
@@ -191,7 +212,7 @@ export function registerAuthRoutes(app: Hono<{ Bindings: Env }>): void {
     const now = new Date();
     await db.insert(users).values({ id, name, role: "user", createdAt: now, updatedAt: now }).onConflictDoNothing();
     setCookie(c, DEV_COOKIE, id, { path: "/", httpOnly: true, sameSite: "Lax", maxAge: 60 * 60 * 24 * 30 });
-    return c.redirect(c.req.query("returnTo") || "/");
+    return c.redirect(internalReturnPath(c.req.query("returnTo"), "/"));
   });
 
   app.get("/api/auth/me", async (c) => c.json({ user: await getUser(c) }));
@@ -205,7 +226,7 @@ export function registerAuthRoutes(app: Hono<{ Bindings: Env }>): void {
 
   // Sign-in page.
   app.get("/login", (c) => {
-    const ret = c.req.query("returnTo") || "/";
+    const ret = internalReturnPath(c.req.query("returnTo"), "/");
     if (c.env.AUTH_MODE !== "oauth") {
       const u = new URL("/api/auth/dev-login", c.req.url);
       u.searchParams.set("returnTo", ret);
@@ -216,7 +237,7 @@ export function registerAuthRoutes(app: Hono<{ Bindings: Env }>): void {
 
   // Sign-out (both modes).
   app.get("/logout", (c) => {
-    const ret = c.req.query("returnTo") || "/";
+    const ret = internalReturnPath(c.req.query("returnTo"), "/");
     if (c.env.AUTH_MODE === "oauth") {
       // Styled to the warm palette so the flash page matches the site (W3 fix #6c).
       return c.html(
@@ -224,7 +245,7 @@ export function registerAuthRoutes(app: Hono<{ Bindings: Env }>): void {
           `<script>(function(){try{var s=localStorage.getItem("wl-theme");var t=s==="dark"||s==="light"?s:(window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");document.documentElement.dataset.theme=t;}catch(e){}})();</script>` +
           `<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f7f4ee;color:#5f594e;display:grid;place-items:center;min-height:100vh;margin:0}` +
           `[data-theme="dark"] body{background:#1a1816;color:#9a9081}</style>` +
-          `<script>fetch("/api/auth/sign-out",{method:"POST"}).then(function(){location.href=${JSON.stringify(ret)}}).catch(function(){location.href=${JSON.stringify(ret)}});</script>` +
+          `<script>fetch("/api/auth/sign-out",{method:"POST"}).then(function(){location.href=${scriptSafeJson(ret)}}).catch(function(){location.href=${scriptSafeJson(ret)}});</script>` +
           `Signing out…`,
       );
     }

--- a/wiki/src/home.ts
+++ b/wiki/src/home.ts
@@ -305,7 +305,7 @@ document.documentElement.dataset.theme=t;}catch(e){}})();
 /* Dark mode — remap the warm-light token palette to the shared dark scheme
    (matches pages.ts / style.css). One override block recolors everything that
    uses the vars; the few hardcoded colors below get explicit dark overrides. */
-[data-theme="dark"] :root {
+:root[data-theme="dark"] {
   --paper:#1a1816; --surface:#232020; --ink:#ebe5d8; --muted:#9a9081;
   --line:#3a3530; --line-strong:#4d4742; --accent:#6e9adf; --accent-dark:#8fb4e8;
   --green:#8fd4ad; --yellow:#e2bf78; --red:#f08e85;

--- a/wiki/src/index.ts
+++ b/wiki/src/index.ts
@@ -446,6 +446,23 @@ function isArticleVersionStaleError(error: unknown): boolean {
   return false;
 }
 
+function guardedBotSaveVersion(
+  slug: string,
+  expectedVersion: number,
+  nextVersion: number,
+  expectedProposalJson: string | null,
+): SQL<number> {
+  return sql<number>`CASE WHEN
+    ${articles.version} = ${expectedVersion}
+    AND (
+      SELECT ${moderationState.proposal} FROM ${moderationState}
+      WHERE ${moderationState.slug} = ${slug}
+    ) IS ${expectedProposalJson}
+    THEN ${nextVersion}
+    ELSE NULL
+  END`;
+}
+
 function guardedProposalDecisionVersion(
   slug: string,
   proposalId: string,
@@ -1804,13 +1821,16 @@ app.post("/api/article/:slug", async (c) => {
       ? (posted.meta as { ladder?: { proposals?: unknown } }).ladder?.proposals
       : undefined;
   let proposalReconciliationStatements: BatchItem<"sqlite">[] = [];
+  let expectedProposalJson: string | null = null;
+  // Runs on EVERY bot save
   // Runs on EVERY bot save (not only ones carrying new proposals): the
   // staleness sweep below must fire even when meta.ladder.proposals is empty,
   // or a dead-target pending proposal survives until someone clicks approve.
   if (isBot) {
     const pnow = Date.now();
     const ms = (await db.select().from(moderationState).where(eq(moderationState.slug, slug)).limit(1))[0];
-    const existingPending = parsePending(ms?.proposal);
+    expectedProposalJson = ms?.proposal ?? null;
+    const existingPending = parsePending(expectedProposalJson);
     // Exclude tombstones: a `rejected` annotation is a human veto and must
     // never be a proposal target (else an approved proposal could resurrect a
     // veto). mergeProposals drops any proposal whose id isn't in this set.
@@ -1928,7 +1948,9 @@ app.post("/api/article/:slug", async (c) => {
       const noopBatch: WriteBatch = [
         db
           .update(articles)
-          .set({ version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${row.version} ELSE NULL END` })
+          .set({
+            version: guardedBotSaveVersion(slug, row.version, row.version, expectedProposalJson),
+          })
           .where(eq(articles.slug, slug)),
         ...proposalReconciliationStatements,
         db
@@ -1977,7 +1999,9 @@ app.post("/api/article/:slug", async (c) => {
       .update(articles)
       .set({
         annotations: annJson,
-        version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${newVersion} ELSE NULL END`,
+        version: isBot
+          ? guardedBotSaveVersion(slug, row.version, newVersion, expectedProposalJson)
+          : sql`CASE WHEN ${articles.version} = ${row.version} THEN ${newVersion} ELSE NULL END`,
         updatedAt: now,
         revid: newRevid,
         ...statusCounts(finalAnnotations),

--- a/wiki/src/index.ts
+++ b/wiki/src/index.ts
@@ -296,7 +296,7 @@ function validateAnnotations(
       return c.json({ ok: false, error: "annotation must be an object" }, 400);
     }
     const ann = a as Record<string, unknown>;
-    if (ann.status !== undefined && (typeof ann.status !== "string" || !STATUS_SET.has(ann.status))) {
+    if (typeof ann.status !== "string" || !STATUS_SET.has(ann.status)) {
       return c.json({ ok: false, error: "invalid status" }, 400);
     }
     // C1: ids are optional (absent → lazily healed on save) but when present
@@ -374,11 +374,10 @@ async function sha256Hex(s: string): Promise<string> {
   return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-// F9: each write path bundles its post-CAS writes (revision insert + events
-// + moderation_state bookkeeping) into ONE db.batch() so a mid-write crash
-// can't leave a revision without its events (or vice versa). D1 executes a
-// batch sequentially in one transaction; the test shim (d1shim) executes it
-// sequentially on one connection. The events' revision_id can't be bound
+// Each mutation unit bundles its guarded article write, revision, events, and
+// moderation/proposal bookkeeping into ONE db.batch(). D1 executes a batch
+// sequentially in one transaction, and the test shim mirrors that behavior.
+// The events' revision_id can't be bound
 // before the batch runs, so event rows reference the batch's own revision
 // insert via a per-slug MAX(id) subquery — valid because the revision insert
 // precedes the event inserts in the same sequential batch.
@@ -433,6 +432,43 @@ function eventInsertStatements(db: DrizzleDB, rows: EventRowInsert[]): BatchItem
 }
 
 type WriteBatch = [BatchItem<"sqlite">, ...BatchItem<"sqlite">[]];
+
+// A guarded article write deliberately assigns NULL to the NOT NULL version
+// column on a lost CAS. D1 aborts the whole batch, so revision/events and
+// moderation/proposal lifecycle writes cannot commit without the article.
+function isArticleVersionStaleError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current !== null; depth += 1) {
+    const message = current instanceof Error ? current.message : typeof current === "string" ? current : "";
+    if (message.includes("NOT NULL constraint failed: articles.version")) return true;
+    current = typeof current === "object" && "cause" in current ? (current as { cause?: unknown }).cause : null;
+  }
+  return false;
+}
+
+async function runGuardedArticleBatch(
+  c: Context<{ Bindings: Env }>,
+  db: DrizzleDB,
+  slug: string,
+  fallback: { version: number; annotations: string },
+  batch: WriteBatch,
+): Promise<Response | null> {
+  try {
+    await db.batch(batch);
+    return null;
+  } catch (error) {
+    if (!isArticleVersionStaleError(error)) throw error;
+    const fresh = (await db.select().from(articles).where(eq(articles.slug, slug)).limit(1))[0];
+    return c.json(
+      {
+        error: "stale",
+        version: fresh ? fresh.version : fallback.version,
+        annotations: JSON.parse(fresh ? fresh.annotations : fallback.annotations),
+      },
+      409,
+    );
+  }
+}
 
 // ---- dynamic homepage + sitemap (D-C7) ----
 // Both are D1-driven (new articles appear without a redeploy) and KV-cached
@@ -755,24 +791,13 @@ app.get("/recent-changes", async (c) => {
 
   const db = drizzle(c.env.DB);
   const patrollers = alias(users, "patrollers");
-  let watchedSlugs: Set<string> | null = null;
-  if (watching) {
-    const ws = await db
-      .select({ slug: watchlist.slug })
-      .from(watchlist)
-      .where(eq(watchlist.userId, user!.id));
-    watchedSlugs = new Set(ws.map((r) => r.slug));
-    if (watchedSlugs.size === 0) {
-      // No watched slugs → no rows, skip the query entirely.
-      const html = recentChangesPage([], {
-        kind,
-        canPatrol: user.role === "patroller" || user.role === "admin",
-        watching: true,
-        loggedIn: true,
-      });
-      return c.html(html);
-    }
-  }
+  const watchedOnly = watching
+    ? sql`EXISTS (
+        SELECT 1 FROM ${watchlist}
+        WHERE ${watchlist.userId} = ${user!.id}
+          AND ${watchlist.slug} = ${revisions.slug}
+      )`
+    : undefined;
 
   const rows = await db
     .select({
@@ -792,13 +817,17 @@ app.get("/recent-changes", async (c) => {
     .leftJoin(articles, eq(articles.slug, revisions.slug))
     .leftJoin(users, eq(users.id, revisions.userId))
     .leftJoin(patrollers, eq(patrollers.id, revisions.patrolledBy))
-    .where(kind === null ? undefined : eq(revisions.kind, kind))
+    .where(
+      and(
+        kind === null ? undefined : eq(revisions.kind, kind),
+        watchedOnly,
+      ),
+    )
     .orderBy(desc(revisions.createdAt))
-    .limit(watching ? 500 : 100); // wider pre-filter window when filtering watchlist
+    .limit(100);
   const canPatrol = user !== null && (user.role === "patroller" || user.role === "admin");
-  const filteredRows = watchedSlugs ? rows.filter((r) => watchedSlugs!.has(r.slug)).slice(0, 100) : rows;
   const html = recentChangesPage(
-    filteredRows.map((r) => ({
+    rows.map((r) => ({
       slug: r.slug,
       displayTitle: r.displayTitle ?? r.slug,
       id: r.id,
@@ -1493,18 +1522,19 @@ app.post("/api/article/:slug", async (c) => {
       const validationErr = validateAnnotations(c, finals, finalsJson);
       if (validationErr) return validationErr;
       const newVersion = row.version + 1;
-      const updated = await db
-        .update(articles)
-        .set({ annotations: finalsJson, version: newVersion, updatedAt: now, ...statusCounts(finals) })
-        .where(and(eq(articles.slug, slug), eq(articles.version, row.version)));
-      if (updated.meta.changes === 0) {
-        const fresh = (await db.select().from(articles).where(eq(articles.slug, slug)).limit(1))[0];
-        return c.json({ error: "stale", version: fresh ? fresh.version : row.version, annotations: fresh ? JSON.parse(fresh.annotations) : [] }, 409);
-      }
       const prior = (
         await db.select({ id: revisions.id }).from(revisions).where(eq(revisions.slug, slug)).orderBy(desc(revisions.id)).limit(1)
       )[0];
-      await db.batch([
+      const approvalBatch: WriteBatch = [
+        db
+          .update(articles)
+          .set({
+            annotations: finalsJson,
+            version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${newVersion} ELSE NULL END`,
+            updatedAt: now,
+            ...statusCounts(finals),
+          })
+          .where(eq(articles.slug, slug)),
         db.insert(revisions).values({
           slug,
           userId: user.id,
@@ -1537,7 +1567,9 @@ app.post("/api/article/:slug", async (c) => {
           .update(proposals)
           .set({ status: "approved", decidedAt: now, decidedBy: user.id })
           .where(and(eq(proposals.id, proposalId), eq(proposals.status, "pending"))),
-      ]);
+      ];
+      const stale = await runGuardedArticleBatch(c, db, slug, row, approvalBatch);
+      if (stale) return stale;
       console.log(JSON.stringify({ event: "proposal-approve", slug, user_id: user.id, actor: isBot ? "ai" : "human", proposal_id: proposalId, version: newVersion, t: now }));
       return c.json({ ok: true, version: newVersion });
     }
@@ -1568,26 +1600,19 @@ app.post("/api/article/:slug", async (c) => {
     const annJson = JSON.stringify(finals);
     const now = Date.now();
     const newVersion = row.version + 1;
-    const updated = await db
-      .update(articles)
-      .set({ annotations: annJson, version: newVersion, updatedAt: now, ...statusCounts(finals) })
-      .where(and(eq(articles.slug, slug), eq(articles.version, row.version)));
-    if (updated.meta.changes === 0) {
-      const fresh = (await db.select().from(articles).where(eq(articles.slug, slug)).limit(1))[0];
-      return c.json(
-        {
-          error: "stale",
-          version: fresh ? fresh.version : row.version,
-          annotations: fresh ? JSON.parse(fresh.annotations) : [],
-        },
-        409,
-      );
-    }
     const prior = (
       await db.select({ id: revisions.id }).from(revisions).where(eq(revisions.slug, slug)).orderBy(desc(revisions.id)).limit(1)
     )[0];
-    // F9: revision + endorse event land atomically.
     const endorseBatch: WriteBatch = [
+      db
+        .update(articles)
+        .set({
+          annotations: annJson,
+          version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${newVersion} ELSE NULL END`,
+          updatedAt: now,
+          ...statusCounts(finals),
+        })
+        .where(eq(articles.slug, slug)),
       db.insert(revisions).values({
         slug,
         userId: user.id,
@@ -1612,7 +1637,8 @@ app.post("/api/article/:slug", async (c) => {
         },
       ]),
     ];
-    await db.batch(endorseBatch);
+    const stale = await runGuardedArticleBatch(c, db, slug, row, endorseBatch);
+    if (stale) return stale;
     console.log(
       JSON.stringify({
         event: "endorse",
@@ -1704,6 +1730,7 @@ app.post("/api/article/:slug", async (c) => {
     isBot && posted.meta && typeof posted.meta === "object"
       ? (posted.meta as { ladder?: { proposals?: unknown } }).ladder?.proposals
       : undefined;
+  let proposalReconciliationStatements: BatchItem<"sqlite">[] = [];
   // Runs on EVERY bot save (not only ones carrying new proposals): the
   // staleness sweep below must fire even when meta.ladder.proposals is empty,
   // or a dead-target pending proposal survives until someone clicks approve.
@@ -1782,7 +1809,7 @@ app.post("/api/article/:slug", async (c) => {
     if (blobChanged || staleNow.length > 0 || noDeltaNow.length > 0 || zombies.length > 0) {
       const proposalJson = merged.length ? JSON.stringify(merged) : null;
       const newOnes = merged.slice(stillPending.length);
-      await db.batch([
+      proposalReconciliationStatements = [
         db
           .insert(moderationState)
           .values({ slug, proposal: proposalJson, updatedAt: pnow })
@@ -1810,7 +1837,7 @@ app.post("/api/article/:slug", async (c) => {
             .set({ status: "stale", decidedAt: pnow })
             .where(and(eq(proposals.id, pid), eq(proposals.status, "pending"))),
         ),
-      ]);
+      ];
     }
   }
 
@@ -1825,13 +1852,22 @@ app.post("/api/article/:slug", async (c) => {
   if (deepEqual(stored, finalAnnotations) && (postedRevid === null || postedRevid === row.revid)) {
     if (isBot) {
       const now = Date.now();
-      await db
-        .insert(moderationState)
-        .values({ slug, lastReviewedAt: now, lastReviewedVersion: row.version, updatedAt: now })
-        .onConflictDoUpdate({
-          target: moderationState.slug,
-          set: { lastReviewedAt: now, lastReviewedVersion: row.version, updatedAt: now },
-        });
+      const noopBatch: WriteBatch = [
+        db
+          .update(articles)
+          .set({ version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${row.version} ELSE NULL END` })
+          .where(eq(articles.slug, slug)),
+        ...proposalReconciliationStatements,
+        db
+          .insert(moderationState)
+          .values({ slug, lastReviewedAt: now, lastReviewedVersion: row.version, updatedAt: now })
+          .onConflictDoUpdate({
+            target: moderationState.slug,
+            set: { lastReviewedAt: now, lastReviewedVersion: row.version, updatedAt: now },
+          }),
+      ];
+      const stale = await runGuardedArticleBatch(c, db, slug, row, noopBatch);
+      if (stale) return stale;
     }
     console.log(
       JSON.stringify({
@@ -1860,42 +1896,20 @@ app.post("/api/article/:slug", async (c) => {
   // Revid policy: articles.revid advances only atomically with the annotations
   // payload — a bot-posted revid re-pins in this same UPDATE, never separately.
   const newRevid = postedRevid ?? wp.revid ?? row.revid;
-  // Guard the UPDATE on the version we read (CAS) to close the TOCTOU between
-  // the read above and this write. If a concurrent save bumped the version,
-  // 0 rows change → treat as stale (same 409 contract).
-  const updated = await db
-    .update(articles)
-    .set({
-      annotations: annJson,
-      version: newVersion,
-      updatedAt: now,
-      revid: newRevid,
-      ...statusCounts(finalAnnotations),
-    })
-    .where(and(eq(articles.slug, slug), eq(articles.version, row.version)));
-  if (updated.meta.changes === 0) {
-    const fresh = (await db.select().from(articles).where(eq(articles.slug, slug)).limit(1))[0];
-    return c.json(
-      {
-        error: "stale",
-        version: fresh ? fresh.version : row.version,
-        annotations: fresh ? JSON.parse(fresh.annotations) : [],
-      },
-      409,
-    );
-  }
-  // D-C8b: a bot re-pin (old revid ≠ new) supersedes the old revision's cached
-  // Wikipedia HTML — drop the stale WP_HTML key (fire-and-forget; the 90d TTL
-  // is the backstop if the delete is lost).
-  if (postedRevid !== null && row.revid !== null && postedRevid !== row.revid) {
-    void c.env.WP_HTML.delete(`wp:${slug}:${row.revid}`).catch(() => {});
-  }
   const prior = (
     await db.select({ id: revisions.id }).from(revisions).where(eq(revisions.slug, slug)).orderBy(desc(revisions.id)).limit(1)
   )[0];
-  // F9: revision + events + moderation bookkeeping land in one atomic batch.
-  // The article UPDATE above stays separate — its CAS result gates all this.
   const saveBatch: WriteBatch = [
+    db
+      .update(articles)
+      .set({
+        annotations: annJson,
+        version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${newVersion} ELSE NULL END`,
+        updatedAt: now,
+        revid: newRevid,
+        ...statusCounts(finalAnnotations),
+      })
+      .where(eq(articles.slug, slug)),
     db.insert(revisions).values({
       slug,
       userId: user.id,
@@ -1918,6 +1932,7 @@ app.post("/api/article/:slug", async (c) => {
         now,
       }),
     ),
+    ...proposalReconciliationStatements,
   ];
   if (isBot) {
     // Bookkeep the review in moderation_state (feeds /api/work priority).
@@ -1945,7 +1960,13 @@ app.post("/api/article/:slug", async (c) => {
         }),
     );
   }
-  await db.batch(saveBatch);
+  const stale = await runGuardedArticleBatch(c, db, slug, row, saveBatch);
+  if (stale) return stale;
+  // A successful re-pin supersedes the old revision's cached Wikipedia HTML.
+  // Delete only after the complete mutation batch commits.
+  if (postedRevid !== null && row.revid !== null && postedRevid !== row.revid) {
+    void c.env.WP_HTML.delete(`wp:${slug}:${row.revid}`).catch(() => {});
+  }
   console.log(
     JSON.stringify({
       event: "save",
@@ -1996,34 +2017,19 @@ app.post("/api/article/:slug/revert/:revid", async (c) => {
 
   const now = Date.now();
   const newVersion = row.version + 1;
-  // F5: same CAS contract as the save path — guard the UPDATE on the version
-  // we read; a concurrent write between the read and this UPDATE leaves
-  // 0 rows changed → 409 stale with the current state.
-  const updated = await db
-    .update(articles)
-    .set({
-      annotations: rev.annotations,
-      version: newVersion,
-      updatedAt: now,
-      ...statusCounts(revAnnotations as AnnRecord[]),
-    })
-    .where(and(eq(articles.slug, slug), eq(articles.version, row.version)));
-  if (updated.meta.changes === 0) {
-    const fresh = (await db.select().from(articles).where(eq(articles.slug, slug)).limit(1))[0];
-    return c.json(
-      {
-        error: "stale",
-        version: fresh ? fresh.version : row.version,
-        annotations: fresh ? JSON.parse(fresh.annotations) : [],
-      },
-      409,
-    );
-  }
   const prior = (
     await db.select({ id: revisions.id }).from(revisions).where(eq(revisions.slug, slug)).orderBy(desc(revisions.id)).limit(1)
   )[0];
-  // F9: revision + revert_restore events land atomically.
   const revertBatch: WriteBatch = [
+    db
+      .update(articles)
+      .set({
+        annotations: rev.annotations,
+        version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${newVersion} ELSE NULL END`,
+        updatedAt: now,
+        ...statusCounts(revAnnotations as AnnRecord[]),
+      })
+      .where(eq(articles.slug, slug)),
     db.insert(revisions).values({
       slug,
       userId: user.id,
@@ -2049,7 +2055,8 @@ app.post("/api/article/:slug/revert/:revid", async (c) => {
       }),
     ),
   ];
-  await db.batch(revertBatch);
+  const stale = await runGuardedArticleBatch(c, db, slug, row, revertBatch);
+  if (stale) return stale;
   console.log(
     JSON.stringify({
       event: "revert",
@@ -2210,21 +2217,6 @@ app.post("/api/admin/revert-run/:runId", async (c) => {
 
     const now = Date.now();
     const newVersion = row.version + 1;
-    // Same CAS contract as the single-revision revert: guard the UPDATE on the
-    // version we read; 0 rows changed = a concurrent write raced us → 'conflict'.
-    const updated = await db
-      .update(articles)
-      .set({
-        annotations: preAnnJson,
-        version: newVersion,
-        updatedAt: now,
-        ...statusCounts(preAnnotations),
-      })
-      .where(and(eq(articles.slug, slug), eq(articles.version, row.version)));
-    if (updated.meta.changes === 0) {
-      skipped.push({ slug, reason: "conflict" });
-      continue;
-    }
     const prior = (
       await db
         .select({ id: revisions.id })
@@ -2233,8 +2225,16 @@ app.post("/api/admin/revert-run/:runId", async (c) => {
         .orderBy(desc(revisions.id))
         .limit(1)
     )[0];
-    // F9: revision + revert_restore events land in one atomic batch (per slug).
     const revertBatch: WriteBatch = [
+      db
+        .update(articles)
+        .set({
+          annotations: preAnnJson,
+          version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${newVersion} ELSE NULL END`,
+          updatedAt: now,
+          ...statusCounts(preAnnotations),
+        })
+        .where(eq(articles.slug, slug)),
       db.insert(revisions).values({
         slug,
         userId: user.id,
@@ -2257,7 +2257,13 @@ app.post("/api/admin/revert-run/:runId", async (c) => {
         }),
       ),
     ];
-    await db.batch(revertBatch);
+    try {
+      await db.batch(revertBatch);
+    } catch (error) {
+      if (!isArticleVersionStaleError(error)) throw error;
+      skipped.push({ slug, reason: "conflict" });
+      continue;
+    }
     reverted.push(slug);
   }
 

--- a/wiki/src/index.ts
+++ b/wiki/src/index.ts
@@ -446,6 +446,30 @@ function isArticleVersionStaleError(error: unknown): boolean {
   return false;
 }
 
+function guardedProposalDecisionVersion(
+  slug: string,
+  proposalId: string,
+  expectedVersion: number,
+  nextVersion: number,
+  expectedProposalJson: string | null,
+): SQL<number> {
+  return sql<number>`CASE WHEN
+    ${articles.version} = ${expectedVersion}
+    AND EXISTS (
+      SELECT 1 FROM ${proposals}
+      WHERE ${proposals.id} = ${proposalId}
+        AND ${proposals.status} = 'pending'
+    )
+    AND EXISTS (
+      SELECT 1 FROM ${moderationState}
+      WHERE ${moderationState.slug} = ${slug}
+        AND ${moderationState.proposal} IS ${expectedProposalJson}
+    )
+    THEN ${nextVersion}
+    ELSE NULL
+  END`;
+}
+
 async function runGuardedArticleBatch(
   c: Context<{ Bindings: Env }>,
   db: DrizzleDB,
@@ -1442,12 +1466,13 @@ app.post("/api/article/:slug", async (c) => {
       }
       if (!isProposalId(posted.proposal_id)) return c.json({ ok: false, error: "bad proposal_id" }, 400);
       const proposalId = posted.proposal_id;
-      // NB: this read → the batch below is a small TOCTOU window against a
-      // concurrent bot-save merge on the same slug (D1 has no read-in-batch).
-      // The window is kept minimal here, and the bot-save sweep self-heals
-      // both divergence directions (zombie table rows ↔ decided blob entries).
+      // D1 has no read-in-batch, so the decision batch below revalidates both
+      // this exact proposal blob and the lifecycle row's pending status before
+      // it changes article or moderation state. A concurrent merge or decision
+      // aborts the whole transaction through the fail-closed article guard.
       const ms = (await db.select().from(moderationState).where(eq(moderationState.slug, slug)).limit(1))[0];
-      const pending = parsePending(ms?.proposal);
+      const expectedProposalJson = ms?.proposal ?? null;
+      const pending = parsePending(expectedProposalJson);
       const prop = pending.find((p) => p.proposalId === proposalId);
       if (!prop) return c.json({ ok: false, error: "proposal not found" }, 404);
       const now = Date.now();
@@ -1458,7 +1483,19 @@ app.post("/api/article/:slug", async (c) => {
         const rejected = parseRejected(ms?.rejectedProposals);
         rejected.push({ annotationId: prop.annotationId, fieldsSig: fieldsSig(prop.fields) });
         const rejectReason = validRejectReason((posted as { reject_reason?: unknown }).reject_reason);
-        await db.batch([
+        const rejectBatch: WriteBatch = [
+          db
+            .update(articles)
+            .set({
+              version: guardedProposalDecisionVersion(
+                slug,
+                proposalId,
+                row.version,
+                row.version,
+                expectedProposalJson,
+              ),
+            })
+            .where(eq(articles.slug, slug)),
           db
             .update(moderationState)
             .set({ proposal: remainingJson, rejectedProposals: JSON.stringify(rejected.slice(-500)), updatedAt: now })
@@ -1468,7 +1505,9 @@ app.post("/api/article/:slug", async (c) => {
             .update(proposals)
             .set({ status: "rejected", rejectReason, decidedAt: now, decidedBy: user.id })
             .where(and(eq(proposals.id, proposalId), eq(proposals.status, "pending"))),
-        ]);
+        ];
+        const stale = await runGuardedArticleBatch(c, db, slug, row, rejectBatch);
+        if (stale) return stale;
         console.log(JSON.stringify({ event: "proposal-reject", slug, user_id: user.id, actor: isBot ? "ai" : "human", proposal_id: proposalId, reject_reason: rejectReason, t: now }));
         return c.json({ ok: true, rejected: true });
       }
@@ -1486,26 +1525,54 @@ app.post("/api/article/:slug", async (c) => {
       const idx = stored.findIndex((a) => a.id === prop.annotationId && a.status !== "rejected");
       if (idx === -1) {
         // Target annotation gone — drop the stale proposal, no content write.
-        await db.batch([
+        const staleTargetBatch: WriteBatch = [
+          db
+            .update(articles)
+            .set({
+              version: guardedProposalDecisionVersion(
+                slug,
+                proposalId,
+                row.version,
+                row.version,
+                expectedProposalJson,
+              ),
+            })
+            .where(eq(articles.slug, slug)),
           db.update(moderationState).set({ proposal: remainingJson, updatedAt: now }).where(eq(moderationState.slug, slug)),
           db
             .update(proposals)
             .set({ status: "stale", decidedAt: now, decidedBy: user.id })
             .where(and(eq(proposals.id, proposalId), eq(proposals.status, "pending"))),
-        ]);
+        ];
+        const stale = await runGuardedArticleBatch(c, db, slug, row, staleTargetBatch);
+        if (stale) return stale;
         return c.json({ ok: false, error: "annotation gone", dropped: true }, 409);
       }
       const { next, changed } = applyProposalFields(stored[idx], prop.fields);
       if (changed.length === 0) {
         // Already matches (e.g. applied by an earlier edit) — just clear it.
         // Lifecycle: approved (the human accepted it; the delta is in effect).
-        await db.batch([
+        const noopApprovalBatch: WriteBatch = [
+          db
+            .update(articles)
+            .set({
+              version: guardedProposalDecisionVersion(
+                slug,
+                proposalId,
+                row.version,
+                row.version,
+                expectedProposalJson,
+              ),
+            })
+            .where(eq(articles.slug, slug)),
           db.update(moderationState).set({ proposal: remainingJson, updatedAt: now }).where(eq(moderationState.slug, slug)),
           db
             .update(proposals)
             .set({ status: "approved", decidedAt: now, decidedBy: user.id })
             .where(and(eq(proposals.id, proposalId), eq(proposals.status, "pending"))),
-        ]);
+        ];
+        const stale = await runGuardedArticleBatch(c, db, slug, row, noopApprovalBatch);
+        if (stale) return stale;
         return c.json({ ok: true, noop: true, version: row.version });
       }
       if (isBot) {
@@ -1530,7 +1597,13 @@ app.post("/api/article/:slug", async (c) => {
           .update(articles)
           .set({
             annotations: finalsJson,
-            version: sql`CASE WHEN ${articles.version} = ${row.version} THEN ${newVersion} ELSE NULL END`,
+            version: guardedProposalDecisionVersion(
+              slug,
+              proposalId,
+              row.version,
+              newVersion,
+              expectedProposalJson,
+            ),
             updatedAt: now,
             ...statusCounts(finals),
           })

--- a/wiki/src/pages.ts
+++ b/wiki/src/pages.ts
@@ -74,7 +74,7 @@ export function injectAuthAndEditor(
       // v=16: save-UX niceties — kind/match_kind <select>s (unknown stored
       // values preserved), comment cleared after save, label-based panel
       // titles, alt-click → Mathlib docs, orphaned-anchor Re-anchor flow.
-      `<script src="/assets/editor.js?v=16"></script>\n`;
+      `<script src="/assets/editor.js?v=17"></script>\n`;
   } else {
     inject =
       `<a id="wl-signin" href="/login?returnTo=${ret}" ` +

--- a/wiki/src/review.ts
+++ b/wiki/src/review.ts
@@ -23,7 +23,7 @@
 import type { Context, Hono } from "hono";
 import { getCookie, setCookie, deleteCookie } from "hono/cookie";
 import type { Env } from "./env.js";
-import { getUser } from "./auth.js";
+import { getUser, internalReturnPath } from "./auth.js";
 
 const GH_API = "https://api.github.com";
 const UA = "WikiLean-review/0.1 (+https://wikilean.jackmccarthy.org)";
@@ -1232,8 +1232,7 @@ export function registerReviewRoutes(app: Hono<{ Bindings: Env }>): void {
     if (!cid || !c.env.REVIEW_GITHUB_CLIENT_SECRET) {
       return c.text("Review OAuth app not configured (set REVIEW_GITHUB_CLIENT_ID/SECRET).", 503);
     }
-    const returnTo = c.req.query("returnTo") || "/review";
-    const safeReturn = returnTo.startsWith("/") ? returnTo : "/review"; // same-origin only
+    const safeReturn = internalReturnPath(c.req.query("returnTo"), "/review");
     const state = crypto.randomUUID();
     setCookie(c, REVIEW_STATE_COOKIE, state + "|" + safeReturn, {
       path: "/review/auth",
@@ -1282,7 +1281,7 @@ export function registerReviewRoutes(app: Hono<{ Bindings: Env }>): void {
       sameSite: "Lax",
       maxAge: REVIEW_TOK_TTL,
     });
-    return c.redirect((returnTo || "/review").startsWith("/") ? returnTo : "/review");
+    return c.redirect(internalReturnPath(returnTo, "/review"));
   });
 
   // Disconnect: drop the stored token + cookie.
@@ -1290,7 +1289,7 @@ export function registerReviewRoutes(app: Hono<{ Bindings: Env }>): void {
     const id = getCookie(c, REVIEW_COOKIE);
     if (id) await c.env.RENDER_CACHE.delete(`reviewtok:${id}`);
     deleteCookie(c, REVIEW_COOKIE, { path: "/" });
-    return c.redirect(c.req.query("returnTo") || "/review");
+    return c.redirect(internalReturnPath(c.req.query("returnTo"), "/review"));
   });
 
   // The review page (shell + client script). no-cache so a deploy's updated

--- a/wiki/test/api.test.ts
+++ b/wiki/test/api.test.ts
@@ -354,6 +354,17 @@ describe("POST /api/article/:slug (save)", () => {
     expect(((await res.json()) as { error: string }).error).toBe("invalid status");
   });
 
+  it("validation: missing status → 400", async () => {
+    const { env } = setup();
+    const res = await save(
+      env,
+      { annotations: [{ anchor: { section: "(lead)", snippet: "abelian group" } }], base_version: 1 },
+      { user: "u-human" },
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid status");
+  });
+
   it("validation: >2000 annotations → 413", async () => {
     const { env } = setup();
     const annotations = Array.from({ length: 2001 }, () => ({ status: "formalized" }));

--- a/wiki/test/atomicity.test.ts
+++ b/wiki/test/atomicity.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  NEW_REVID,
+  PIPELINE_TOKEN,
+  REVID,
+  SEED_ANNOTATIONS,
+  SLUG,
+  articleRow,
+  blockNetwork,
+  echo,
+  eventRows,
+  post,
+  revisionCount,
+  save,
+  setup,
+} from "./helpers/harness.js";
+
+blockNetwork();
+
+function bumpBeforeBatch(env: unknown, bump: () => void): void {
+  const d1 = env as { batch: (statements: unknown[]) => Promise<unknown> };
+  const originalBatch = d1.batch.bind(d1);
+  let bumped = false;
+  d1.batch = async (statements) => {
+    if (!bumped) {
+      bumped = true;
+      bump();
+    }
+    return originalBatch(statements);
+  };
+}
+
+describe("article mutation atomicity", () => {
+  it("a stale guarded save appends no revision or annotation event", async () => {
+    const { db, env } = setup();
+    const annotations = echo(SEED_ANNOTATIONS) as Array<Record<string, unknown>>;
+    annotations[0].note = "racing edit";
+    bumpBeforeBatch(env.DB, () => {
+      db.prepare("UPDATE articles SET version = version + 1 WHERE slug = ?").run(SLUG);
+    });
+
+    const response = await save(env, { annotations, base_version: 1 }, { user: "u-human" });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: "stale", version: 2 });
+    expect(revisionCount(db)).toBe(1);
+    expect(eventRows(db)).toEqual([]);
+    expect(JSON.parse(articleRow(db)!.annotations)).toEqual(SEED_ANNOTATIONS);
+  });
+
+  it("a later batch failure rolls the guarded article write back", async () => {
+    const { db, env } = setup();
+    db.exec("CREATE TRIGGER fail_revision BEFORE INSERT ON revisions BEGIN SELECT RAISE(ABORT, 'forced revision failure'); END");
+    const before = articleRow(db)!;
+    const annotations = echo(SEED_ANNOTATIONS) as Array<Record<string, unknown>>;
+    annotations[0].note = "must roll back";
+
+    const response = await save(env, { annotations, base_version: 1 }, { user: "u-human" });
+
+    expect(response.status).toBe(500);
+    expect(articleRow(db)).toEqual(before);
+    expect(revisionCount(db)).toBe(1);
+    expect(eventRows(db)).toEqual([]);
+  });
+
+  it("a failed bot re-pin keeps the old Wikipedia HTML cache entry", async () => {
+    const { db, env, wpHtml } = setup();
+    db.exec("CREATE TRIGGER fail_revision BEFORE INSERT ON revisions BEGIN SELECT RAISE(ABORT, 'forced revision failure'); END");
+    const annotations = [...echo(SEED_ANNOTATIONS), {
+      id: "cccccccccccc",
+      status: "formalized",
+      kind: "theorem",
+      label: "Subgroups of abelian groups are normal",
+      provenance: "ai",
+      anchor: { section: "Properties", snippet: "Every subgroup of an abelian group is normal" },
+      mathlib: { decl: "Subgroup.Normal", module: "Mathlib.GroupTheory.Subgroup.Basic", match_kind: "exact" },
+    }];
+
+    const response = await post(
+      env,
+      `/api/article/${SLUG}`,
+      { annotations, base_version: 1, revid: NEW_REVID },
+      { bearer: PIPELINE_TOKEN, origin: null },
+    );
+
+    expect(response.status).toBe(500);
+    expect(articleRow(db)!.revid).toBe(REVID);
+    expect(wpHtml.store.has(`wp:${SLUG}:${REVID}`)).toBe(true);
+  });
+});

--- a/wiki/test/auth-redirects.test.ts
+++ b/wiki/test/auth-redirects.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { internalReturnPath, scriptSafeJson } from "../src/auth.js";
+import { app } from "../src/index.js";
+import type { Env } from "../src/env.js";
+import { get, setup } from "./helpers/harness.js";
+
+const HOSTILE_RETURN_PATHS = [
+  "javascript:alert(1)",
+  "https://evil.example/path",
+  "//evil.example/path",
+  "/\\evil.example/path",
+  "/safe\nLocation: https://evil.example",
+];
+
+function oauthHarness() {
+  const h = setup();
+  h.env.AUTH_MODE = "oauth";
+  return h;
+}
+
+function reviewHarness() {
+  const h = setup();
+  h.env.REVIEW_GITHUB_CLIENT_ID = "Iv1.test";
+  h.env.REVIEW_GITHUB_CLIENT_SECRET = "secret";
+  h.env.BETTER_AUTH_URL = "https://wikilean.example";
+  return h;
+}
+
+function request(env: Env, path: string, headers?: Record<string, string>): Promise<Response> {
+  return Promise.resolve(app.request(path, { headers }, env));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("internalReturnPath", () => {
+  it("accepts a single-leading-slash local path with query and fragment", () => {
+    expect(internalReturnPath("/review?repo=leanprover-community/mathlib4&pr=42#Q1", "/fallback")).toBe(
+      "/review?repo=leanprover-community/mathlib4&pr=42#Q1",
+    );
+  });
+
+  it.each(HOSTILE_RETURN_PATHS)("rejects hostile return target %j", (value) => {
+    expect(internalReturnPath(value, "/fallback")).toBe("/fallback");
+  });
+});
+
+describe("main auth returnTo handling", () => {
+  it("preserves a valid internal path through login and dev-login", async () => {
+    const h = setup();
+    const login = await get(h.env, "/login?returnTo=%2Fflags%3Fstatus%3Dopen");
+    expect(login.status).toBe(302);
+    expect(login.headers.get("Location")).toBe("/api/auth/dev-login?returnTo=%2Fflags%3Fstatus%3Dopen");
+
+    const devLogin = await get(h.env, "/api/auth/dev-login?returnTo=%2Fflags%3Fstatus%3Dopen");
+    expect(devLogin.status).toBe(302);
+    expect(devLogin.headers.get("Location")).toBe("/flags?status=open");
+  });
+
+  it.each(HOSTILE_RETURN_PATHS)("falls back for hostile login and dev-login target %j", async (value) => {
+    const h = setup();
+    const encoded = encodeURIComponent(value);
+    const login = await get(h.env, `/login?returnTo=${encoded}`);
+    expect(login.headers.get("Location")).toBe("/api/auth/dev-login?returnTo=%2F");
+
+    const devLogin = await get(h.env, `/api/auth/dev-login?returnTo=${encoded}`);
+    expect(devLogin.headers.get("Location")).toBe("/");
+  });
+
+  it.each(HOSTILE_RETURN_PATHS)("falls back for hostile logout target %j", async (value) => {
+    const h = setup();
+    const response = await get(h.env, `/logout?returnTo=${encodeURIComponent(value)}`);
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/");
+  });
+
+  it("serializes login and logout destinations without allowing an inline-script breakout", async () => {
+    const h = oauthHarness();
+    const returnTo = "/</script><script>alert(1)</script>\u2028\u2029";
+    const encoded = encodeURIComponent(returnTo);
+
+    const loginHtml = await (await request(h.env, `/login?returnTo=${encoded}`)).text();
+    expect(loginHtml).toContain(`var ret=${scriptSafeJson(returnTo)};`);
+    expect(loginHtml).not.toContain(`var ret=${JSON.stringify(returnTo)};`);
+
+    const logoutHtml = await (await request(h.env, `/logout?returnTo=${encoded}`)).text();
+    expect(logoutHtml).toContain(`location.href=${scriptSafeJson(returnTo)}`);
+    expect(logoutHtml).not.toContain(`location.href=${JSON.stringify(returnTo)}`);
+    expect(scriptSafeJson(returnTo)).toContain("\\u003c/script>");
+    expect(scriptSafeJson(returnTo)).toContain("\\u2028");
+    expect(scriptSafeJson(returnTo)).toContain("\\u2029");
+    h.db.close();
+  });
+});
+
+describe("review auth returnTo handling", () => {
+  it("preserves a valid internal path through OAuth start and logout", async () => {
+    const h = reviewHarness();
+    const returnTo = "/review?repo=owner/repo&pr=42";
+    const start = await request(h.env, `/review/auth/start?returnTo=${encodeURIComponent(returnTo)}`);
+    expect(start.status).toBe(302);
+    expect(decodeURIComponent(start.headers.get("Set-Cookie") || "")).toContain(`|${returnTo}`);
+
+    const logout = await request(h.env, `/review/auth/logout?returnTo=${encodeURIComponent(returnTo)}`);
+    expect(logout.status).toBe(302);
+    expect(logout.headers.get("Location")).toBe(returnTo);
+    h.db.close();
+  });
+
+  it.each(HOSTILE_RETURN_PATHS)("falls back for hostile OAuth start and logout target %j", async (value) => {
+    const h = reviewHarness();
+    const encoded = encodeURIComponent(value);
+    const start = await request(h.env, `/review/auth/start?returnTo=${encoded}`);
+    expect(decodeURIComponent(start.headers.get("Set-Cookie") || "")).toContain("|/review");
+
+    const logout = await request(h.env, `/review/auth/logout?returnTo=${encoded}`);
+    expect(logout.headers.get("Location")).toBe("/review");
+    h.db.close();
+  });
+
+  it("preserves a valid return target from the OAuth state cookie", async () => {
+    const h = reviewHarness();
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "token" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ login: "reviewer" }), { status: 200 }));
+
+    const returnTo = "/review?repo=owner/repo&pr=42";
+    const cookie = `wl_review_oauth=${encodeURIComponent(`state|${returnTo}`)}`;
+    const callback = await request(h.env, "/review/auth/callback?code=code&state=state", { Cookie: cookie });
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get("Location")).toBe(returnTo);
+    h.db.close();
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "https://evil.example/path",
+    "//evil.example/path",
+    "/\\evil.example/path",
+    "/safe\nLocation: https://evil.example",
+  ])("revalidates a hostile return target from the OAuth state cookie: %j", async (value) => {
+    const h = reviewHarness();
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "token" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ login: "reviewer" }), { status: 200 }));
+
+    const cookie = `wl_review_oauth=${encodeURIComponent(`state|${value}`)}`;
+    const callback = await request(h.env, "/review/auth/callback?code=code&state=state", { Cookie: cookie });
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get("Location")).toBe("/review");
+    h.db.close();
+  });
+});

--- a/wiki/test/create.test.ts
+++ b/wiki/test/create.test.ts
@@ -195,6 +195,7 @@ describe("PUT /api/article/:slug (create)", () => {
       { wikipedia_title: "X", revid: "777", annotations: [] }, // F16: must be a number
       { wikipedia_title: "X", revid: 777 }, // no annotations array
       { wikipedia_title: "X", revid: 777, annotations: [{ status: "bogus" }] }, // same validator as saves
+      { wikipedia_title: "X", revid: 777, annotations: [{ anchor: { section: "(lead)", snippet: "X" } }] },
       { wikipedia_title: "X", revid: 777, display_title: "", annotations: [] },
       { wikipedia_title: "X", revid: 777, meta: "not-an-object", annotations: [] },
     ];

--- a/wiki/test/drift.test.ts
+++ b/wiki/test/drift.test.ts
@@ -164,7 +164,7 @@ describe("staleness banner (injectAuthAndEditor)", () => {
     expect(html).toContain("wl-stale-banner");
     // v=16: editor save-UX niceties (selects / comment clear / alt-click /
     // re-anchor) — keep in lockstep with pages.ts.
-    expect(html).toContain("/assets/editor.js?v=16");
+    expect(html).toContain("/assets/editor.js?v=17");
     expect(html).not.toContain("editor.js?v=10");
   });
 });

--- a/wiki/test/editor-focus-contract.test.ts
+++ b/wiki/test/editor-focus-contract.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const editorPath = fileURLToPath(new URL("../assets/editor.js", import.meta.url));
+const source = readFileSync(editorPath, "utf8");
+
+function functionBody(name: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  expect(start, `${name} should exist`).toBeGreaterThanOrEqual(0);
+
+  const brace = source.indexOf("{", start);
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    if (source[i] === "}" && --depth === 0) return source.slice(brace + 1, i);
+  }
+  throw new Error(`could not find the end of ${name}`);
+}
+
+describe("editor dialog focus source contract", () => {
+  it("captures a stable opener before moving focus into either dialog mode", () => {
+    const editBody = functionBody("openEditor");
+    const addBody = functionBody("openAdder");
+
+    for (const body of [editBody, addBody]) {
+      expect(body).toContain("rememberDialogOpener(opener);");
+      expect(body.indexOf("rememberDialogOpener(opener);")).toBeLessThan(
+        body.indexOf('panel.classList.add("open")'),
+      );
+      expect(body.indexOf('panel.classList.add("open")')).toBeLessThan(
+        body.indexOf('$("wlr-f-status").focus()'),
+      );
+    }
+
+    const rememberBody = functionBody("rememberDialogOpener");
+    expect(rememberBody).toContain('panel.classList.contains("open")');
+    expect(rememberBody).toContain("document.activeElement");
+    expect(rememberBody).toContain("defaultDialogFallback()");
+  });
+
+  it("traps Tab and Shift+Tab among visible enabled dialog controls", () => {
+    const focusableBody = functionBody("focusableDialogControls");
+    expect(focusableBody).toContain("button,input,select,textarea");
+    expect(focusableBody).toContain("el.disabled");
+    expect(focusableBody).toContain('style.display !== "none"');
+    expect(focusableBody).toContain('style.visibility !== "hidden"');
+    expect(focusableBody).toContain("el.getClientRects().length > 0");
+
+    const trapBody = functionBody("trapDialogTab");
+    expect(trapBody).toContain("e.shiftKey");
+    expect(trapBody).toContain("last.focus()");
+    expect(trapBody).toContain("first.focus()");
+    expect(source).toContain('e.key === "Tab" && panel.classList.contains("open")');
+    expect(source).toContain("trapDialogTab(e);");
+  });
+
+  it("restores focus after close and never targets picker rows or the hidden FAB", () => {
+    const stableBody = functionBody("isStableFocusTarget");
+    expect(stableBody).toContain("el.isConnected");
+    expect(stableBody).toContain('!el.closest("#wlr-picker")');
+    expect(stableBody).toContain("el !== fab");
+
+    const closeBody = functionBody("closePanel");
+    expect(closeBody).toContain('panel.classList.remove("open")');
+    expect(closeBody).toContain("restoreDialogFocus();");
+    expect(closeBody.indexOf('panel.classList.remove("open")')).toBeLessThan(
+      closeBody.indexOf("restoreDialogFocus();"),
+    );
+
+    expect(source).toContain("openEditor(i, annoEl);");
+    expect(source).toContain("openAdder(pendingSel.text, pendingSel.section, articleBody);");
+    expect(source.match(/openEditor\([^\n]+, e\.currentTarget\);/g)).toHaveLength(3);
+  });
+
+  it("preserves Escape, save shortcut, and dirty-close confirmation behavior", () => {
+    expect(source).toMatch(
+      /if \(e\.key === "Escape"\) \{[\s\S]*?if \(panel\.classList\.contains\("open"\)\) requestClose\(\);/,
+    );
+    expect(source).toMatch(
+      /\(e\.metaKey \|\| e\.ctrlKey\) && e\.key === "Enter"[\s\S]*?e\.preventDefault\(\);[\s\S]*?save\(\);/,
+    );
+
+    const requestCloseBody = functionBody("requestClose");
+    expect(requestCloseBody).toContain('confirm("Discard unsaved changes?")');
+    expect(requestCloseBody).toContain("closePanel();");
+    expect(source).toContain('$("wlr-close").addEventListener("click", requestClose);');
+  });
+});

--- a/wiki/test/helpers/d1shim.ts
+++ b/wiki/test/helpers/d1shim.ts
@@ -10,12 +10,10 @@
 //       `{ results }` as row objects.
 //   client.prepare(sql).bind(...params).raw()   → typed selects; needs rows
 //       as positional value arrays in SELECT-clause order.
-//   client.batch(statements)                    → F9: the write paths bundle
-//       their post-CAS writes (and drift.ts its sweep bookkeeping) into one
-//       batch. The shim executes statements sequentially on the shared
-//       connection and returns one D1Result-shaped object per statement
-//       (real D1 batch is also sequential, plus transactional — the shim
-//       skips the transaction; no test asserts on mid-batch rollback).
+//   client.batch(statements)                    → the write paths bundle each
+//       mutation unit into one transaction. The shim executes statements
+//       sequentially under BEGIN IMMEDIATE and returns one D1Result-shaped
+//       object per statement, matching D1's commit-or-rollback behavior.
 // exec()/first() are not exercised by the app and throw loudly.
 
 import { DatabaseSync, type StatementSync } from "node:sqlite";
@@ -123,11 +121,24 @@ function makeStatement(db: DatabaseSync, sql: string, params: SqliteParam[]): D1
 export function makeD1(db: DatabaseSync) {
   return {
     prepare: (sql: string) => makeStatement(db, sql, []),
-    // Sequential (per-statement) execution — see the header note.
     batch: async (stmts: D1ShimStatement[]) => {
       const out: D1ShimResult[] = [];
-      for (const s of stmts) out.push(await s._batchExec());
-      return out;
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        for (const s of stmts) out.push(await s._batchExec());
+        db.exec("COMMIT");
+        return out;
+      } catch (error) {
+        // A statement using SQLite's ROLLBACK conflict action may already have
+        // ended the transaction. Never let a second rollback mask the original
+        // failure that production D1 would report to the caller.
+        try {
+          db.exec("ROLLBACK");
+        } catch {
+          // Transaction already rolled back by the failing statement.
+        }
+        throw error;
+      }
     },
     exec: () => {
       throw new Error("d1shim: exec() not implemented");

--- a/wiki/test/home.test.ts
+++ b/wiki/test/home.test.ts
@@ -141,8 +141,10 @@ describe("homePage", () => {
     // The toggle button.
     expect(html).toContain('id="wl-theme-toggle"');
     expect(html).toContain('class="wl-theme-toggle"');
-    // At least one dark-theme rule, and the shared dark palette anchor color.
-    expect(html).toContain('[data-theme="dark"]');
+    // Theme tokens live on the root element that receives data-theme. A
+    // descendant selector can never match because :root is the document root.
+    expect(html).toContain(':root[data-theme="dark"] {');
+    expect(html).not.toContain('[data-theme="dark"] :root');
     expect(html).toContain("--paper:#1a1816");
   });
 

--- a/wiki/test/patrol.test.ts
+++ b/wiki/test/patrol.test.ts
@@ -93,6 +93,29 @@ describe("GET /recent-changes?kind=", () => {
     expect(html).not.toContain('class="wl-unpatrolled"'); // (bare substring would hit the shell CSS)
     expect(html).not.toContain(`data-rev="${pipelineId}"`);
   });
+
+  it("filters watched slugs before applying the result limit", async () => {
+    const h = setup();
+    h.db.prepare("INSERT INTO watchlist (user_id, slug, created_at) VALUES (?,?,?)").run(
+      "u-human",
+      SLUG,
+      Date.now(),
+    );
+    h.db
+      .prepare("UPDATE revisions SET comment = ?, created_at = ? WHERE id = 1")
+      .run("older-watched-change", 1);
+    for (let i = 0; i < 501; i += 1) {
+      insertRevision(h.db, `Unwatched_${i}`, {
+        kind: "edit",
+        comment: `newer-unwatched-${i}`,
+        createdAt: i + 2,
+      });
+    }
+
+    const html = await (await get(h.env, "/recent-changes?watching=1", { user: "u-human" })).text();
+    expect(html).toContain("older-watched-change");
+    expect(html).not.toContain("newer-unwatched-500");
+  });
 });
 
 describe("POST /api/revision/:id/patrol", () => {

--- a/wiki/test/proposals.test.ts
+++ b/wiki/test/proposals.test.ts
@@ -12,6 +12,7 @@ import {
   articleRow,
   storedAnnotations,
   latestRevision,
+  revisionCount,
   eventRows,
   blockNetwork,
   echo,
@@ -160,6 +161,46 @@ describe("POST /api/article/:slug (proposals)", () => {
 
     // Proposal consumed.
     expect(pending(db)).toHaveLength(0);
+  });
+
+  it("does not apply an approval after a concurrent rejection wins", async () => {
+    const { db, env } = setup();
+    await seedProposal(env);
+    await storeProposal(env, db, 2);
+    const proposal = pending(db)[0];
+    const revisionsBefore = revisionCount(db);
+    const articleBefore = articleRow(db)!;
+
+    const d1 = env.DB as unknown as { batch: (statements: unknown[]) => Promise<unknown> };
+    const originalBatch = d1.batch.bind(d1);
+    let raced = false;
+    d1.batch = async (statements) => {
+      if (!raced) {
+        raced = true;
+        db.prepare("UPDATE proposals SET status = 'rejected', reject_reason = 'incorrect', decided_at = ?, decided_by = ? WHERE id = ?")
+          .run(Date.now(), "u-admin", proposal.proposalId);
+        db.prepare("UPDATE moderation_state SET proposal = NULL, rejected_proposals = ? WHERE slug = ?")
+          .run(JSON.stringify([{ annotationId: HUMAN_ID, fieldsSig: fieldsSig(PROP_FIELDS) }]), SLUG);
+      }
+      return originalBatch(statements);
+    };
+
+    const response = await save(
+      env,
+      { action: "approve_proposal", proposal_id: proposal.proposalId, base_version: 2 },
+      { user: "u-patroller" },
+    );
+
+    expect(response.status).toBe(409);
+    expect(articleRow(db)).toEqual(articleBefore);
+    expect(revisionCount(db)).toBe(revisionsBefore);
+    expect(storedAnnotations(db).find((a) => a.id === HUMAN_ID)!.status).toBe("partial");
+    const lifecycle = db.prepare("SELECT status, decided_by FROM proposals WHERE id = ?").get(proposal.proposalId) as {
+      status: string;
+      decided_by: string | null;
+    };
+    expect(lifecycle).toEqual({ status: "rejected", decided_by: "u-admin" });
+    expect(pending(db)).toEqual([]);
   });
 
   it("dual-writes the lifecycle table: pending on store, approved/rejected(+reason) on decision", async () => {

--- a/wiki/test/proposals.test.ts
+++ b/wiki/test/proposals.test.ts
@@ -119,7 +119,7 @@ describe("proposals — inline banner injection", () => {
     });
     expect(html).toContain("window.__WL_PROPOSALS__=");
     expect(html).toContain("abc123abc123");
-    expect(html).toContain("editor.js?v=16");
+    expect(html).toContain("editor.js?v=17");
 
     const anon = injectAuthAndEditor("<main></main>", { slug: "Foo", user: null, annotations: [], proposals });
     expect(anon).not.toContain("__WL_PROPOSALS__");

--- a/wiki/test/proposals.test.ts
+++ b/wiki/test/proposals.test.ts
@@ -163,6 +163,61 @@ describe("POST /api/article/:slug (proposals)", () => {
     expect(pending(db)).toHaveLength(0);
   });
 
+  it("does not overwrite a proposal queue changed by a concurrent bot save", async () => {
+    const { db, env } = setup();
+    await seedProposal(env);
+    const articleBefore = articleRow(db)!;
+    const competing: PendingProposal = {
+      proposalId: "dddddddddddd",
+      annotationId: HUMAN_ID,
+      fields: { note: "concurrent proposal" },
+      reason: "concurrent review",
+      createdAt: 123,
+    };
+
+    const d1 = env.DB as unknown as { batch: (statements: unknown[]) => Promise<unknown> };
+    const originalBatch = d1.batch.bind(d1);
+    let raced = false;
+    d1.batch = async (statements) => {
+      if (!raced) {
+        raced = true;
+        db.prepare("INSERT INTO moderation_state (slug, proposal, updated_at) VALUES (?,?,?)")
+          .run(SLUG, JSON.stringify([competing]), Date.now());
+        db.prepare("INSERT INTO proposals (id, slug, annotation_id, fields, fields_sig, reason, status, created_at) VALUES (?,?,?,?,?,?,?,?)")
+          .run(
+            competing.proposalId,
+            SLUG,
+            HUMAN_ID,
+            JSON.stringify(competing.fields),
+            fieldsSig(competing.fields),
+            competing.reason,
+            "pending",
+            competing.createdAt,
+          );
+      }
+      return originalBatch(statements);
+    };
+
+    const response = await botSave(env, {
+      annotations: storedAnnotations(db).map(echo),
+      base_version: 2,
+      meta: {
+        ladder: {
+          proposals: [{ annotationId: HUMAN_ID, fields: PROP_FIELDS, reason: "stale review" }],
+        },
+      },
+    });
+
+    expect(response.status).toBe(409);
+    expect(articleRow(db)).toEqual(articleBefore);
+    expect(pending(db)).toEqual([competing]);
+    const rows = db.prepare("SELECT id, status FROM proposals ORDER BY id").all() as Array<{
+      id: string;
+      status: string;
+    }>;
+    expect(rows).toEqual([{ id: competing.proposalId, status: "pending" }]);
+  });
+
   it("does not apply an approval after a concurrent rejection wins", async () => {
     const { db, env } = setup();
     await seedProposal(env);


### PR DESCRIPTION
## Summary

- harden main and review OAuth return targets against reflected script injection and off-site redirects
- commit article state, revisions, annotation events, proposal lifecycle, and moderation bookkeeping atomically under a fail-closed CAS
- reject annotations without a valid status and filter watchlist revisions before pagination
- fix article-directory dark mode and trap/restore focus in the annotation editor dialog

## Regression coverage

- hostile login/logout/review OAuth return targets, including `</script>` payloads
- stale article writes and mid-batch D1 rollback, including re-pin cache ordering
- missing annotation statuses through save and create paths
- watched revisions older than 500 unrelated global changes
- dark-theme selector and editor focus behavior source contracts

## Test plan

- `validate_changes` (clean)
- VS Code diagnostics for all modified TypeScript/JavaScript/test files (clean)
- `git diff --cached --check` (clean before commit)
- two independent code-review passes (no blocking findings)
- local `npm test` and `npx tsc --noEmit` unavailable because this environment has no Node/npm; CI should run both
- repository agent-validator could not start because its Arcanist wrapper requires unavailable PHP

## Notes

The reserved-route collision identified in the original review was already fixed on current `main`, so this PR does not duplicate that change.