### PR TITLE
ci: add dependable pull request validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  worker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: wiki
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: wiki/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck and test Worker
+        run: npm run test:ci
+
+  python:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      PYTHONUNBUFFERED: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-ci.txt
+
+      - name: Install deterministic test dependencies
+        run: python -m pip install --requirement requirements-ci.txt
+
+      - name: Run deterministic Python checks
+        run: scripts/ci-python.sh
+
+  browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CI: "true"
+    defaults:
+      run:
+        working-directory: wiki
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: wiki/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser tests
+        run: npm run test:e2e
+
+      - name: Upload browser failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: browser-failure-artifacts
+          path: |
+            wiki/playwright-report/
+            wiki/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  required:
+    if: always()
+    needs: [worker, python]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify required jobs
+        env:
+          WORKER_RESULT: ${{ needs.worker.result }}
+          PYTHON_RESULT: ${{ needs.python.result }}
+        run: |
+          if [[ "$WORKER_RESULT" != "success" || "$PYTHON_RESULT" != "success" ]]; then
+            echo "Required CI failed: worker=$WORKER_RESULT python=$PYTHON_RESULT"
+            exit 1
+          fi
+          echo "Required CI passed: worker=$WORKER_RESULT python=$PYTHON_RESULT"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ node_modules/
 dist/
 build/
 .next/
+wiki/playwright-report/
+wiki/test-results/
 
 # Lean
 .lake/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,25 @@ Repo remote: `origin` = `Deicyde/WikiLean`. Branch from `main`; PRs → `Deicyde
 
 ## Commands
 
+Use Node 22 and Python 3.12. The JavaScript package root is `wiki/`; use `npm ci`
+there to reproduce the lockfile exactly.
+
 ```bash
+# Required, hermetic CI checks
+cd wiki && npm ci
+cd wiki && npm run test:ci         # typecheck + hermetic Worker tests
+./scripts/ci-python.sh             # deterministic Python checks (run at repo root)
+
+# Browser soak (Chromium; local loopback only, no external requests)
+cd wiki && npx playwright install chromium
+cd wiki && npm run test:e2e
+
+# Corpus-dependent local checks (not required fresh-checkout CI)
+cd wiki && npm run test:corpus     # renderer/annotation/decl-index corpora
+python3 brain/test_fold_xref.py    # real catalog + private decl cache/Mathlib checkout
+
 # Site (wiki/)
 cd wiki && npm run deploy          # deploy the Worker (bundles ALL of wiki/src)
-cd wiki && npx tsc --noEmit        # typecheck
-cd wiki && npm test                # Worker tests
 cd wiki && node --experimental-strip-types scripts/build-public.ts   # rebuild static assets (RUN FROM wiki/)
 # Tagging bot
 gh workflow run wikidata-poll.yml --repo Deicyde/WikiLean
@@ -64,7 +78,7 @@ python3 manage/refresh.py [--pull] # rebuild the control plane (centrality/cover
   path outside the Worker must bump `version`, or readers see stale pages for up to 30 days.
 - **`findLostHuman` 422 is the floor** — a bot save that drops/alters any `provenance:"human"`
   annotation (tombstones included) must 422. Bots can't approve/endorse (session-only; 403).
-- **Render-cache keys are manually versioned + load-bearing** (currently `render:v16:`,
+- **Render-cache keys are manually versioned + load-bearing** (currently `render:v17:`,
   `page:home:v10`, `page:articles:v2`, `page:articles-index:v1`, `page:about:v1`,
   `page:sitemap:v4`, `page:stats:v4`, `page:wikifunctions:v3`,
   `page:wikifunctions-verify:v3` — all in `index.ts`) — bump the
@@ -82,12 +96,31 @@ python3 manage/refresh.py [--pull] # rebuild the control plane (centrality/cover
   FETCH_HEAD` (never `reset --hard`); **never `git add -A`** (stage explicit paths + leak guard).
 
 **Security / credentials**
+- `.github/workflows/ci.yml` is validation only: read-only repository permissions, checkout
+  credentials disabled, no secrets, no deployments, no production writes, and no token-consuming
+  agent calls. Its `required` job aggregates only the `worker` and `python` hermetic gates.
+- The separate Playwright `browser` job is a non-required soak on every CI trigger. Failures upload
+  `wiki/playwright-report/` and `wiki/test-results/` as `browser-failure-artifacts` for 7 days.
+  Promote it into `required` only through a reviewed workflow change after stable run history; there
+  is no automatic threshold.
 - `.dev.vars` is gitignored and holds secrets — never commit, never print values; set Worker
   secrets via `wrangler secret put` / `gh secret set`.
 - **Max-auth gotcha**: unset `ANTHROPIC_API_KEY` before `claude`/SDK calls or they fail silently
   ("error result: success", 0 tokens).
 - Never take custody of others' API keys. Never edit the mathlib4 checkout — do Lean work in
   `wikifunctions/lean/`.
+
+## CI test boundaries
+- `npm test` / `npm run test:unit` excludes corpus-dependent Vitest files. `npm run test:ci` is
+  the named Worker gate; `./scripts/ci-python.sh` is the Python 3.12 gate and unsets credential
+  variables before running all five offline commands with required SDK coverage.
+- `npm run test:corpus` preflights `site/cache/*.html`, `site/out/*.html`,
+  `site/annotations/*.json`, and `wiki/public/assets/decl-index/manifest.json`, then runs the
+  render-golden, decl-index, and seed suites. `brain/test_fold_xref.py` is also corpus-only because
+  it needs the private declaration cache at `.claude/skills/mathlib-search/.cache/declaration-data.json`
+  (with `BRAIN_MATHLIB_CHECKOUT` as its checkout override).
+- Playwright uses Chromium. Local install is `npx playwright install chromium`; Linux CI uses
+  `npx playwright install --with-deps chromium`.
 
 ## Deploy notes
 - `npm run deploy` bundles **all** of `wiki/src` — don't leave unreleased Worker WIP committed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,11 +40,25 @@ Repo remote: `origin` = `Deicyde/WikiLean`. Branch from `main`; PRs → `Deicyde
 
 ## Commands
 
+Use Node 22 and Python 3.12. The JavaScript package root is `wiki/`; use `npm ci`
+there to reproduce the lockfile exactly.
+
 ```bash
+# Required, hermetic CI checks
+cd wiki && npm ci
+cd wiki && npm run test:ci         # typecheck + hermetic Worker tests
+./scripts/ci-python.sh             # deterministic Python checks (run at repo root)
+
+# Browser soak (Chromium; local loopback only, no external requests)
+cd wiki && npx playwright install chromium
+cd wiki && npm run test:e2e
+
+# Corpus-dependent local checks (not required fresh-checkout CI)
+cd wiki && npm run test:corpus     # renderer/annotation/decl-index corpora
+python3 brain/test_fold_xref.py    # real catalog + private decl cache/Mathlib checkout
+
 # Site (wiki/)
 cd wiki && npm run deploy          # deploy the Worker (bundles ALL of wiki/src)
-cd wiki && npx tsc --noEmit        # typecheck
-cd wiki && npm test                # Worker tests
 cd wiki && node --experimental-strip-types scripts/build-public.ts   # rebuild static assets (RUN FROM wiki/)
 # Tagging bot
 gh workflow run wikidata-poll.yml --repo Deicyde/WikiLean
@@ -68,7 +82,7 @@ python3 manage/refresh.py [--pull] # rebuild the control plane (centrality/cover
   decide proposals (approve/reject), and an AI approve that changes human bytes re-labels
   them `ai-moderated` — **AI-changed bytes are never left marked `human`, and bots never
   mint `human`** (endorse stays session-only; 403). Humans gate only cross-site pushes.
-- **Render-cache keys are manually versioned + load-bearing** (currently `render:v16:`,
+- **Render-cache keys are manually versioned + load-bearing** (currently `render:v17:`,
   `page:home:v10`, `page:articles:v2`, `page:articles-index:v1`, `page:about:v1`,
   `page:sitemap:v4`, `page:stats:v5`, `page:wikifunctions:v3`,
   `page:wikifunctions-verify:v3` — all in `index.ts`) — bump the
@@ -86,12 +100,31 @@ python3 manage/refresh.py [--pull] # rebuild the control plane (centrality/cover
   FETCH_HEAD` (never `reset --hard`); **never `git add -A`** (stage explicit paths + leak guard).
 
 **Security / credentials**
+- `.github/workflows/ci.yml` is validation only: read-only repository permissions, checkout
+  credentials disabled, no secrets, no deployments, no production writes, and no token-consuming
+  agent calls. Its `required` job aggregates only the `worker` and `python` hermetic gates.
+- The separate Playwright `browser` job is a non-required soak on every CI trigger. Failures upload
+  `wiki/playwright-report/` and `wiki/test-results/` as `browser-failure-artifacts` for 7 days.
+  Promote it into `required` only through a reviewed workflow change after stable run history; there
+  is no automatic threshold.
 - `.dev.vars` is gitignored and holds secrets — never commit, never print values; set Worker
   secrets via `wrangler secret put` / `gh secret set`.
 - **Max-auth gotcha**: unset `ANTHROPIC_API_KEY` before `claude`/SDK calls or they fail silently
   ("error result: success", 0 tokens).
 - Never take custody of others' API keys. Never edit the mathlib4 checkout — do Lean work in
   `wikifunctions/lean/`.
+
+## CI test boundaries
+- `npm test` / `npm run test:unit` excludes corpus-dependent Vitest files. `npm run test:ci` is
+  the named Worker gate; `./scripts/ci-python.sh` is the Python 3.12 gate and unsets credential
+  variables before running all five offline commands with required SDK coverage.
+- `npm run test:corpus` preflights `site/cache/*.html`, `site/out/*.html`,
+  `site/annotations/*.json`, and `wiki/public/assets/decl-index/manifest.json`, then runs the
+  render-golden, decl-index, and seed suites. `brain/test_fold_xref.py` is also corpus-only because
+  it needs the private declaration cache at `.claude/skills/mathlib-search/.cache/declaration-data.json`
+  (with `BRAIN_MATHLIB_CHECKOUT` as its checkout override).
+- Playwright uses Chromium. Local install is `npx playwright install chromium`; Linux CI uses
+  `npx playwright install --with-deps chromium`.
 
 ## Deploy notes
 - `npm run deploy` bundles **all** of `wiki/src` — don't leave unreleased Worker WIP committed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,10 +70,65 @@ See [catalog/README.md](catalog/README.md) for full details.
 - Cloudflare Worker, Hono framework, Drizzle ORM, D1, KV, R2.
 - See [wiki/README.md](wiki/README.md) for setup and deploy instructions.
 
+### Development setup and checks
+
+Use **Node 22** and **Python 3.12**, matching `.github/workflows/ci.yml`. Install the locked JavaScript dependencies from the package directory; use `npm ci`, not `npm install`, when reproducing CI:
+
+```sh
+cd wiki
+npm ci
+```
+
+The named Worker commands are:
+
+```sh
+npm test              # alias for the hermetic Vitest suite (`test:unit`)
+npm run test:unit     # Worker tests that need no generated/private corpus
+npm run typecheck     # TypeScript, including the browser harness
+npm run test:ci       # required Worker gate: typecheck + hermetic tests
+```
+
+The deterministic Python gate runs from the repository root. It installs the exact packages in `requirements-ci.txt`, asserts Python 3.12, removes credential variables from its environment, and runs the moderation, parity, offline-evaluation, and hermetic Brain fixture checks:
+
+```sh
+python3.12 -m pip install --requirement requirements-ci.txt
+./scripts/ci-python.sh
+```
+
+The offline moderation evaluation uses planted fixtures and no agents, network, or tokens. Never run its `--live` mode in CI.
+
+#### Browser tests
+
+The Playwright suite runs Chromium against a loopback-only server backed by the same in-memory D1/KV fixture as the Worker tests; both the browser and server reject external requests. Install the pinned npm dependencies first, then install and run Chromium:
+
+```sh
+cd wiki
+npm ci
+npx playwright install chromium
+npm run test:e2e
+```
+
+Linux CI uses `npx playwright install --with-deps chromium` to install system dependencies too. Failures retain traces and screenshots under `wiki/test-results/`; CI also writes the HTML report under `wiki/playwright-report/` and uploads both directories as the seven-day `browser-failure-artifacts` artifact.
+
+The browser job currently runs on every CI trigger as a **non-required soak**. Branch protection should require only the aggregate `required` job, which covers the Worker and Python jobs. Promote browser testing into that aggregate only through a reviewed workflow change after its run history is stable; there is no automatic promotion threshold.
+
+#### Corpus-dependent checks
+
+Corpus checks are opt-in because their large/generated or private inputs are not available in a fresh checkout. From `wiki/`, run:
+
+```sh
+npm run test:corpus
+```
+
+Its preflight requires more than 200 cached Wikipedia pages in `site/cache/*.html`, more than 200 Python renderer outputs in `site/out/*.html`, more than 250 annotations in `site/annotations/*.json`, and the generated declaration-index manifest at `wiki/public/assets/decl-index/manifest.json`. The command then runs the render golden, declaration-index, and seed corpus suites.
+
+`python3 brain/test_fold_xref.py` is also corpus-dependent, not part of required Python CI. It uses the real catalog plus the private declaration cache at `.claude/skills/mathlib-search/.cache/declaration-data.json` (and may fall back to the Mathlib checkout configured by `BRAIN_MATHLIB_CHECKOUT`). Run it only after those local inputs exist.
+
 ### Pull requests
 - Branch from `main`, push, open a PR against `Deicyde/WikiLean`.
 - For substantive changes, open an issue first to discuss scope.
-- Tests: `cd wiki && npm test` for the Worker side; the Python side has no test suite yet, contributions welcome.
+- `.github/workflows/ci.yml` runs on pull requests, pushes to `main`, and manual dispatch. It has read-only repository permissions, checks out without persisted credentials, receives no secrets, and contains no deployment, production write, or token-consuming step.
+- The required `worker` and `python` jobs use Node 22 and Python 3.12 respectively. The `required` aggregate is the branch-protection target; the separate `browser` job is the soak described above.
 
 ---
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,36 @@
+# Fully resolved Python 3.12 environment for scripts/ci-python.sh.
+# Refresh intentionally from a clean virtual environment after the complete suite passes.
+annotated-types==0.8.0
+anyio==4.14.2
+attrs==26.1.0
+certifi==2026.7.22
+cffi==2.1.1
+charset-normalizer==3.5.1
+claude-agent-sdk==0.2.144
+click==8.4.2
+cryptography==50.0.0
+h11==0.16.0
+httpcore2==2.12.0
+httpx2==2.12.0
+idna==3.19
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+mcp==2.1.0
+mcp-types==2.1.0
+opentelemetry-api==1.44.0
+pycparser==3.0
+pydantic==2.13.4
+pydantic_core==2.46.4
+PyJWT==2.13.0
+python-multipart==0.0.32
+referencing==0.37.0
+requests==2.34.2
+rpds-py==2026.6.3
+sniffio==1.3.1
+sse-starlette==3.4.8
+starlette==1.6.0
+truststore==0.10.4
+typing-inspection==0.4.4
+typing_extensions==4.16.0
+urllib3==2.7.0
+uvicorn==0.52.4

--- a/scripts/ci-python.sh
+++ b/scripts/ci-python.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON:-python3}"
+
+cd "$ROOT"
+export PYTHONHASHSEED=0
+export PYTHONDONTWRITEBYTECODE=1
+export TZ=UTC
+
+# CI must never inherit credentials that could turn an offline test into a live call.
+unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN PIPELINE_TOKEN CLOUDFLARE_API_TOKEN
+
+run_check() {
+  local name="$1"
+  shift
+  printf '\n==> %s\n' "$name"
+  printf '    '
+  printf '%q ' "$@"
+  printf '\n'
+  "$@"
+}
+
+"$PYTHON_BIN" -c 'import sys; assert sys.version_info[:2] == (3, 12), f"Python 3.12 required, found {sys.version.split()[0]}"'
+
+run_check "moderation unit tests" "$PYTHON_BIN" site/test_moderate.py
+run_check "cross-language parity tests" "$PYTHON_BIN" site/test_parity.py
+run_check "offline moderation evaluation" "$PYTHON_BIN" site/eval_moderation.py --offline --require-all
+run_check "Brain v2 fixture tests" "$PYTHON_BIN" brain/test_v2.py
+run_check "Brain harvest fixture tests" "$PYTHON_BIN" brain/test_harvest.py
+
+printf '\nCI Python summary: 5 commands passed; all required offline scenarios ran.\n'

--- a/wiki/e2e/server.ts
+++ b/wiki/e2e/server.ts
@@ -1,0 +1,68 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { serve } from "@hono/node-server";
+import { app } from "../src/index.js";
+import { setup } from "../test/helpers/fixture.js";
+
+const HOST = "127.0.0.1";
+const PORT = Number.parseInt(process.env.WIKILEAN_E2E_PORT ?? "4173", 10);
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const SOURCE_ASSETS = new Map<string, { path: string; contentType: string }>([
+  ["/assets/style.css", { path: resolve(ROOT, "../site/assets/style.css"), contentType: "text/css; charset=utf-8" }],
+  ["/assets/script.js", { path: resolve(ROOT, "../site/assets/script.js"), contentType: "text/javascript; charset=utf-8" }],
+  ["/assets/review.css", { path: resolve(ROOT, "../site/assets/review.css"), contentType: "text/css; charset=utf-8" }],
+  ["/assets/editor.js", { path: resolve(ROOT, "assets/editor.js"), contentType: "text/javascript; charset=utf-8" }],
+]);
+
+const GENERATED_ASSET_FIXTURES = new Map<string, { body: string; contentType: string }>([
+  ["/favicon.ico", { body: "", contentType: "image/x-icon" }],
+  ["/assets/mathlib-index.json", { body: "[]", contentType: "application/json" }],
+  [
+    "/assets/decl-index/manifest.json",
+    { body: JSON.stringify({ v: 1, scheme: { max_len: 2 }, shards: {} }), contentType: "application/json" },
+  ],
+]);
+
+const harness = setup();
+const runtimeFetch = globalThis.fetch;
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  throw new Error(`browser harness attempted an external fetch: ${String(input)}`);
+}) as typeof globalThis.fetch;
+
+async function fetch(request: Request): Promise<Response> {
+  const pathname = new URL(request.url).pathname;
+  const asset = SOURCE_ASSETS.get(pathname);
+  if (asset) {
+    return new Response(await readFile(asset.path), {
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": asset.contentType,
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  }
+  const generated = GENERATED_ASSET_FIXTURES.get(pathname);
+  if (generated) {
+    return new Response(generated.body, {
+      headers: { "Cache-Control": "no-store", "Content-Type": generated.contentType },
+    });
+  }
+  return app.fetch(request, harness.env);
+}
+
+const server = serve({ fetch, hostname: HOST, port: PORT }, (info) => {
+  console.log(`WikiLean browser harness listening on http://${HOST}:${info.port}`);
+});
+
+function shutdown(): void {
+  server.close(() => {
+    globalThis.fetch = runtimeFetch;
+    harness.db.close();
+    process.exit(0);
+  });
+}
+
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/wiki/e2e/wiki.spec.ts
+++ b/wiki/e2e/wiki.spec.ts
@@ -1,0 +1,117 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+const ARTICLE_PATH = "/Test_Article";
+
+function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+  page.on("response", (response) => {
+    if (response.status() >= 400) errors.push(`response ${response.status()}: ${response.url()}`);
+  });
+  return errors;
+}
+
+async function rejectExternalRequests(page: Page): Promise<void> {
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.hostname !== "127.0.0.1" && url.hostname !== "localhost") {
+      throw new Error(`browser test attempted an external request: ${url.href}`);
+    }
+    await route.continue();
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await rejectExternalRequests(page);
+});
+
+test("renders the seeded article without serious accessibility violations", async ({ page }) => {
+  const errors = collectPageErrors(page);
+  await page.goto(ARTICLE_PATH);
+
+  await expect(page).toHaveTitle("WikiLean · Test Article");
+  await expect(page.getByRole("main")).toContainText("abelian group");
+  await expect(page.locator(".anno")).toHaveCount(2);
+  await expect(page.getByRole("link", { name: "Sign in to edit" })).toHaveAttribute(
+    "href",
+    "/login?returnTo=%2FTest_Article",
+  );
+
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+  const seriousViolations = results.violations.filter(
+    (violation) => violation.impact === "serious" || violation.impact === "critical",
+  );
+  expect(seriousViolations).toEqual([]);
+  expect(errors).toEqual([]);
+});
+
+test("returns to the article after development login", async ({ page }) => {
+  const errors = collectPageErrors(page);
+  await page.goto(ARTICLE_PATH);
+  await page.getByRole("link", { name: "Sign in to edit" }).click();
+
+  await expect(page).toHaveURL(/\/Test_Article$/);
+  await expect(page.locator("#wlr-bar")).toContainText("editing as Dev User");
+  await expect(page.getByRole("link", { name: "Sign in to edit" })).toHaveCount(0);
+  expect(errors).toEqual([]);
+});
+
+test("rejects a hostile login return target without leaving loopback", async ({ page }) => {
+  await page.goto(`/login?returnTo=${encodeURIComponent("javascript:globalThis.__wlInjected=true")}`);
+
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page).toHaveTitle(/WikiLean/);
+  expect(new URL(page.url()).hostname).toBe("127.0.0.1");
+  expect(await page.evaluate(() => Reflect.get(globalThis, "__wlInjected"))).toBeUndefined();
+});
+
+test("persists an explicit theme selection across reload", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "light" });
+  await page.goto(ARTICLE_PATH);
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+
+  await page.getByRole("button", { name: "Toggle dark mode" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await expect.poll(() => page.evaluate(() => localStorage.getItem("wl-theme"))).toBe("dark");
+
+  await page.reload();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+});
+
+test("moves, traps, and restores focus for the annotation editor", async ({ page }) => {
+  await page.goto(`/login?returnTo=${encodeURIComponent(ARTICLE_PATH)}`);
+  await expect(page).toHaveURL(/\/Test_Article$/);
+  await page.evaluate(() => localStorage.setItem("wl_editor_intro_seen", "1"));
+  await page.reload();
+
+  const highlight = page.locator(".anno").first();
+  await highlight.click();
+
+  const dialog = page.getByRole("dialog", { name: /Edit: Abelian group/ });
+  await expect(dialog).toBeVisible();
+  await expect(page.getByLabel("Status", { exact: true })).toBeFocused();
+
+  const close = page.getByRole("button", { name: "Close editor" });
+  await close.focus();
+  await page.keyboard.press("Shift+Tab");
+  await expect(dialog.getByRole("button", { name: "Delete" })).toBeFocused();
+
+  const label = page.getByLabel("Label", { exact: true });
+  await label.fill("Unsaved label");
+  page.once("dialog", async (confirmation) => confirmation.dismiss());
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeVisible();
+  await expect(label).toBeFocused();
+  await expect(label).toHaveValue("Unsaved label");
+
+  await label.fill("Abelian group");
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await expect(highlight).toBeFocused();
+});

--- a/wiki/package-lock.json
+++ b/wiki/package-lock.json
@@ -11,7 +11,10 @@
         "hono": "^4.6.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
         "@cloudflare/workers-types": "^4.20241218.0",
+        "@hono/node-server": "^1.19.1",
+        "@playwright/test": "^1.55.0",
         "@types/node": "^22.10.0",
         "tsx": "^4.23.1",
         "typescript": "^5.7.0",
@@ -4173,6 +4176,105 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     }
   }

--- a/wiki/package.json
+++ b/wiki/package.json
@@ -3,8 +3,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run",
+    "test": "npm run test:unit",
+    "test:unit": "vitest run",
+    "test:corpus": "node scripts/check-corpus-tests.mjs && vitest run --config vitest.corpus.config.ts",
+    "test:e2e": "playwright test",
+    "test:ci": "npm run typecheck && npm run test:unit",
     "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
     "seed:sql": "node --experimental-strip-types scripts/seed.ts",
     "seed:delta": "node --experimental-strip-types scripts/seed-delta.ts",
     "seed:refresh": "node --experimental-strip-types scripts/seed-refresh.ts",
@@ -26,7 +31,10 @@
     "hono": "^4.6.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
     "@cloudflare/workers-types": "^4.20241218.0",
+    "@hono/node-server": "^1.19.1",
+    "@playwright/test": "^1.55.0",
     "@types/node": "^22.10.0",
     "tsx": "^4.23.1",
     "typescript": "^5.7.0",

--- a/wiki/playwright.config.ts
+++ b/wiki/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number.parseInt(process.env.WIKILEAN_E2E_PORT ?? "4173", 10);
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["line"], ["html", { open: "never" }]] : "list",
+  outputDir: "test-results",
+  use: {
+    ...devices["Desktop Chrome"],
+    baseURL,
+    serviceWorkers: "block",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "exec tsx e2e/server.ts",
+    url: `${baseURL}/Test_Article`,
+    reuseExistingServer: false,
+    timeout: 30_000,
+    env: { WIKILEAN_E2E_PORT: String(port) },
+  },
+});

--- a/wiki/scripts/check-corpus-tests.mjs
+++ b/wiki/scripts/check-corpus-tests.mjs
@@ -1,0 +1,38 @@
+import { existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "../..");
+const requirements = [
+  {
+    path: resolve(root, "site/cache"),
+    description: "cached Wikipedia HTML (more than 200 *.html files)",
+    validate: (path) => existsSync(path) && readdirSync(path).filter((name) => name.endsWith(".html")).length > 200,
+  },
+  {
+    path: resolve(root, "site/out"),
+    description: "Python renderer output (more than 200 *.html files)",
+    validate: (path) => existsSync(path) && readdirSync(path).filter((name) => name.endsWith(".html")).length > 200,
+  },
+  {
+    path: resolve(root, "site/annotations"),
+    description: "annotation corpus (more than 250 *.json files)",
+    validate: (path) => existsSync(path) && readdirSync(path).filter((name) => name.endsWith(".json")).length > 250,
+  },
+  {
+    path: resolve(root, "wiki/public/assets/decl-index/manifest.json"),
+    description: "generated Mathlib declaration-index manifest",
+    validate: existsSync,
+  },
+];
+
+const missing = requirements.filter(({ path, validate }) => !validate(path));
+if (missing.length > 0) {
+  console.error("Corpus test preflight failed. These opt-in tests need generated local data:");
+  for (const requirement of missing) {
+    console.error(`  - ${requirement.description}: ${requirement.path}`);
+  }
+  console.error("See CONTRIBUTING.md for corpus setup. The hermetic CI suite is `npm test`.");
+  process.exit(1);
+}
+
+console.log("Corpus test preflight passed: renderer, annotation, and declaration-index inputs are present.");

--- a/wiki/src/engine/page.ts
+++ b/wiki/src/engine/page.ts
@@ -167,8 +167,8 @@ document.documentElement.dataset.theme=t;}catch(e){}})();
    dark mode along with the rest of the chrome. */
 .wl-attribution { max-width: 1000px; margin: 24px auto 40px; padding: 12px 16px 0; border-top: 1px solid var(--line-strong); color: var(--muted); font-size: 12px; line-height: 1.5; }
 .wl-attribution p { margin: 4px 0; }
-.wl-attribution a { color: var(--accent); text-decoration: none; }
-.wl-attribution a:hover { text-decoration: underline; }
+.wl-attribution a { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }
+.wl-attribution a:hover { text-decoration-thickness: 2px; }
 /* Trust signals (P2): the human-reviewed badge + the header legend popover.
    Styled with the stylesheet's tokens only, so dark mode recolors them for
    free ([data-theme="dark"] remaps every var used here). */

--- a/wiki/src/index.ts
+++ b/wiki/src/index.ts
@@ -163,7 +163,8 @@ async function renderArticleBase(env: Env, row: ArticleRow): Promise<string> {
   // body — CSS-only so anchor signatures are untouched).
   // v16: trust signals (P2) — the N/M human-reviewed header badge + the "?"
   // legend popover (engine/page.ts; CSS/JS inline in the page shell).
-  const cacheKey = `render:v16:${slug}:${row.version}`;
+  // v17: attribution links are always underlined so they do not rely on color.
+  const cacheKey = `render:v17:${slug}:${row.version}`;
   const cached = await env.RENDER_CACHE.get(cacheKey);
   if (cached) return cached;
 

--- a/wiki/test/decl.corpus.test.ts
+++ b/wiki/test/decl.corpus.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { declShardFor } from "../src/decl.js";
+
+describe("declShardFor against the real manifest", () => {
+  it("resolves every declaration the review found missing", async () => {
+    const { readFileSync } = await import("node:fs");
+    const manifest = JSON.parse(
+      readFileSync(new URL("../public/assets/decl-index/manifest.json", import.meta.url), "utf8"),
+    );
+    for (const name of [
+      "Set",
+      "Int",
+      "Fin",
+      "Add",
+      "LE",
+      "Algebra",
+      "Continuous",
+      "CategoryTheory.Functor",
+      "Group",
+      "Real",
+    ]) {
+      expect(declShardFor(manifest, name), `shard for ${name}`).not.toBeNull();
+    }
+  });
+});

--- a/wiki/test/decl.test.ts
+++ b/wiki/test/decl.test.ts
@@ -35,16 +35,6 @@ describe("declShardFor", () => {
   });
 });
 
-describe("declShardFor against the REAL manifest", () => {
-  it("resolves every decl the review found missing (padded-leaf names)", async () => {
-    const { readFileSync } = await import("node:fs");
-    const manifest = JSON.parse(readFileSync(new URL("../public/assets/decl-index/manifest.json", import.meta.url), "utf8"));
-    for (const name of ["Set", "Int", "Fin", "Add", "LE", "Algebra", "Continuous", "CategoryTheory.Functor", "Group", "Real"]) {
-      expect(declShardFor(manifest, name), `shard for ${name}`).not.toBeNull();
-    }
-  });
-});
-
 describe("lookupInShard", () => {
   const pairs: Array<[string, string]> = [
     ["Nat.Prime", "Mathlib.Data.Nat.Prime.Defs"],

--- a/wiki/test/helpers/fixture.ts
+++ b/wiki/test/helpers/fixture.ts
@@ -1,0 +1,110 @@
+// Framework-neutral test fixture for exercising the real Hono application.
+// Vitest request helpers and the Playwright loopback server both build their
+// environment from this module, so browser tests use the same D1/KV state as
+// the Worker request suites.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Env } from "../../src/env.js";
+import { makeD1, makeKV, type KVShim } from "./d1shim.js";
+
+export const SLUG = "Test_Article";
+export const REVID = 12345;
+export const NEW_REVID = 67890;
+export const PIPELINE_TOKEN = "test-pipeline-token";
+export const ORIGIN = "http://localhost";
+export const ID_RE = /^[0-9a-f]{12}$/;
+export const TEST_IP = "203.0.113.7";
+
+const MIGRATIONS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../../migrations");
+const MIGRATIONS = readdirSync(MIGRATIONS_DIR)
+  .filter((file) => file.endsWith(".sql"))
+  .sort();
+
+export const WP_FIXTURE = [
+  '<p>In mathematics, an <b>abelian group</b> is a <a href="/wiki/Group_(mathematics)">group</a> whose operation is commutative.</p>',
+  "<h2>Properties</h2>",
+  "<p>Every subgroup of an abelian group is normal. The fundamental theorem of finite abelian groups classifies them completely.</p>",
+].join("\n");
+
+export const SEED_ANNOTATIONS = [
+  {
+    id: "aaaaaaaaaaaa",
+    status: "formalized",
+    kind: "definition",
+    label: "Abelian group",
+    provenance: "ai",
+    anchor: { section: "(lead)", snippet: "abelian group" },
+    mathlib: { decl: "AddCommGroup", module: "Mathlib.Algebra.Group.Defs", match_kind: "exact" },
+  },
+  {
+    id: "bbbbbbbbbbbb",
+    status: "partial",
+    kind: "theorem",
+    label: "Fundamental theorem of finite abelian groups",
+    provenance: "ai",
+    anchor: { section: "Properties", snippet: "fundamental theorem of finite abelian groups" },
+    mathlib: { decl: null, module: null, match_kind: null },
+  },
+];
+
+export const EXTRA_ANNOTATION = {
+  status: "formalized",
+  kind: "theorem",
+  label: "Subgroups of abelian groups are normal",
+  provenance: "ai",
+  anchor: { section: "Properties", snippet: "Every subgroup of an abelian group is normal" },
+  mathlib: { decl: "Subgroup.Normal", module: "Mathlib.GroupTheory.Subgroup.Basic", match_kind: "exact" },
+};
+
+export const echo = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+export interface Harness {
+  db: DatabaseSync;
+  env: Env;
+  renderCache: KVShim;
+  wpHtml: KVShim;
+}
+
+export function setup(
+  opts: { limiterAllows?: boolean; flagLimiterAllows?: boolean; brainApiLimiterAllows?: boolean } = {},
+): Harness {
+  const db = new DatabaseSync(":memory:");
+  for (const file of MIGRATIONS) db.exec(readFileSync(resolve(MIGRATIONS_DIR, file), "utf8"));
+
+  const now = Date.now();
+  db.prepare(
+    "INSERT INTO articles (slug, wikipedia_title, display_title, wikidata_qid, revid, annotations, version, created_at, updated_at) VALUES (?,?,?,?,?,?,1,?,?)",
+  ).run(SLUG, "Test Article", "Test Article", null, REVID, JSON.stringify(SEED_ANNOTATIONS), now, now);
+  db.prepare("INSERT INTO revisions (slug, user_id, annotations, comment, created_at) VALUES (?,NULL,?,?,?)").run(
+    SLUG,
+    JSON.stringify(SEED_ANNOTATIONS),
+    "seed import",
+    now,
+  );
+
+  const nowSec = Math.floor(now / 1000);
+  const insUser = db.prepare("INSERT INTO users (id, name, email, role, created_at, updated_at) VALUES (?,?,?,?,?,?)");
+  insUser.run("u-human", "Human Tester", "human@example.org", "user", nowSec, nowSec);
+  insUser.run("u-patroller", "Pat Roller", "pat@example.org", "patroller", nowSec, nowSec);
+  insUser.run("u-admin", "Ad Min", "admin@example.org", "admin", nowSec, nowSec);
+  insUser.run("u-blocked", "Block Ed", "blocked@example.org", "blocked", nowSec, nowSec);
+  insUser.run("pipeline", "WikiLean Pipeline", null, "bot", nowSec, nowSec);
+
+  const renderCache = makeKV();
+  const wpHtml = makeKV({ [`wp:${SLUG}:${REVID}`]: WP_FIXTURE, [`wp:${SLUG}:${NEW_REVID}`]: WP_FIXTURE });
+  const env = {
+    DB: makeD1(db),
+    RENDER_CACHE: renderCache,
+    WP_HTML: wpHtml,
+    ASSETS: { fetch: async () => new Response("not found", { status: 404 }) },
+    EDIT_LIMITER: { limit: async () => ({ success: opts.limiterAllows ?? true }) },
+    FLAG_LIMITER: { limit: async () => ({ success: opts.flagLimiterAllows ?? true }) },
+    BRAIN_API_LIMITER: { limit: async () => ({ success: opts.brainApiLimiterAllows ?? true }) },
+    AUTH_MODE: "dev",
+    PIPELINE_TOKEN,
+  } as unknown as Env;
+  return { db, env, renderCache, wpHtml };
+}

--- a/wiki/test/helpers/harness.ts
+++ b/wiki/test/helpers/harness.ts
@@ -4,69 +4,27 @@
 // re-declare it. api.test.ts keeps its own copy deliberately — it pins the
 // pre-Wave-D contracts and must stay independently readable.
 
-import { readFileSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { beforeAll, afterAll } from "vitest";
 import { app } from "../../src/index.js";
 import type { Env } from "../../src/env.js";
-import { makeD1, makeKV, type KVShim } from "./d1shim.js";
+import { ORIGIN, PIPELINE_TOKEN, SLUG } from "./fixture.js";
 
-export const SLUG = "Test_Article";
-export const REVID = 12345;
-export const NEW_REVID = 67890;
-export const PIPELINE_TOKEN = "test-pipeline-token";
-export const ORIGIN = "http://localhost"; // app.request() URLs resolve against this
-export const ID_RE = /^[0-9a-f]{12}$/;
-export const TEST_IP = "203.0.113.7"; // RFC 5737 documentation range
-
-const MIGRATIONS_DIR = resolve(process.cwd(), "migrations");
-const MIGRATIONS = readdirSync(MIGRATIONS_DIR)
-  .filter((f) => f.endsWith(".sql"))
-  .sort();
-
-export const WP_FIXTURE = [
-  '<p>In mathematics, an <b>abelian group</b> is a <a href="/wiki/Group_(mathematics)">group</a> whose operation is commutative.</p>',
-  "<h2>Properties</h2>",
-  "<p>Every subgroup of an abelian group is normal. The fundamental theorem of finite abelian groups classifies them completely.</p>",
-].join("\n");
-
-// Unlike the api.test.ts fixtures, these carry explicit ids (the production
-// state since the C1 backfill) so by-id event diffs are exercised directly —
-// a modify reads as 'modify', not as a fresh-id 'add'.
-export const SEED_ANNOTATIONS = [
-  {
-    id: "aaaaaaaaaaaa",
-    status: "formalized",
-    kind: "definition",
-    label: "Abelian group",
-    provenance: "ai",
-    anchor: { section: "(lead)", snippet: "abelian group" },
-    mathlib: { decl: "AddCommGroup", module: "Mathlib.Algebra.Group.Defs", match_kind: "exact" },
-  },
-  {
-    id: "bbbbbbbbbbbb",
-    status: "partial",
-    kind: "theorem",
-    label: "Fundamental theorem of finite abelian groups",
-    provenance: "ai",
-    anchor: { section: "Properties", snippet: "fundamental theorem of finite abelian groups" },
-    mathlib: { decl: null, module: null, match_kind: null },
-  },
-];
-
-// A third annotation a test can add (anchors in WP_FIXTURE's Properties section).
-export const EXTRA_ANNOTATION = {
-  status: "formalized",
-  kind: "theorem",
-  label: "Subgroups of abelian groups are normal",
-  provenance: "ai",
-  anchor: { section: "Properties", snippet: "Every subgroup of an abelian group is normal" },
-  mathlib: { decl: "Subgroup.Normal", module: "Mathlib.GroupTheory.Subgroup.Basic", match_kind: "exact" },
-};
-
-// Deep clone via JSON round-trip: what a client posts after reading state.
-export const echo = <T>(x: T): T => JSON.parse(JSON.stringify(x)) as T;
+export {
+  EXTRA_ANNOTATION,
+  ID_RE,
+  NEW_REVID,
+  ORIGIN,
+  PIPELINE_TOKEN,
+  REVID,
+  SEED_ANNOTATIONS,
+  SLUG,
+  TEST_IP,
+  WP_FIXTURE,
+  echo,
+  setup,
+  type Harness,
+} from "./fixture.js";
 
 // No test may hit the network. Call once per test file at describe scope.
 export function blockNetwork(): void {
@@ -79,55 +37,6 @@ export function blockNetwork(): void {
   afterAll(() => {
     globalThis.fetch = realFetch;
   });
-}
-
-export interface Harness {
-  db: DatabaseSync;
-  env: Env;
-  renderCache: KVShim;
-  wpHtml: KVShim;
-}
-
-export function setup(
-  opts: { limiterAllows?: boolean; flagLimiterAllows?: boolean; brainApiLimiterAllows?: boolean } = {},
-): Harness {
-  const db = new DatabaseSync(":memory:");
-  for (const f of MIGRATIONS) db.exec(readFileSync(resolve(MIGRATIONS_DIR, f), "utf8"));
-
-  const now = Date.now();
-  db.prepare(
-    "INSERT INTO articles (slug, wikipedia_title, display_title, wikidata_qid, revid, annotations, version, created_at, updated_at) VALUES (?,?,?,?,?,?,1,?,?)",
-  ).run(SLUG, "Test Article", "Test Article", null, REVID, JSON.stringify(SEED_ANNOTATIONS), now, now);
-  db.prepare("INSERT INTO revisions (slug, user_id, annotations, comment, created_at) VALUES (?,NULL,?,?,?)").run(
-    SLUG,
-    JSON.stringify(SEED_ANNOTATIONS),
-    "seed import",
-    now,
-  );
-
-  // users.created_at/updated_at are timestamp-mode (integer seconds).
-  const nowSec = Math.floor(now / 1000);
-  const insUser = db.prepare("INSERT INTO users (id, name, email, role, created_at, updated_at) VALUES (?,?,?,?,?,?)");
-  insUser.run("u-human", "Human Tester", "human@example.org", "user", nowSec, nowSec);
-  insUser.run("u-patroller", "Pat Roller", "pat@example.org", "patroller", nowSec, nowSec);
-  insUser.run("u-admin", "Ad Min", "admin@example.org", "admin", nowSec, nowSec);
-  insUser.run("u-blocked", "Block Ed", "blocked@example.org", "blocked", nowSec, nowSec);
-  insUser.run("pipeline", "WikiLean Pipeline", null, "bot", nowSec, nowSec);
-
-  const renderCache = makeKV();
-  const wpHtml = makeKV({ [`wp:${SLUG}:${REVID}`]: WP_FIXTURE, [`wp:${SLUG}:${NEW_REVID}`]: WP_FIXTURE });
-  const env = {
-    DB: makeD1(db),
-    RENDER_CACHE: renderCache,
-    WP_HTML: wpHtml,
-    ASSETS: { fetch: async () => new Response("not found", { status: 404 }) },
-    EDIT_LIMITER: { limit: async () => ({ success: opts.limiterAllows ?? true }) },
-    FLAG_LIMITER: { limit: async () => ({ success: opts.flagLimiterAllows ?? true }) },
-    BRAIN_API_LIMITER: { limit: async () => ({ success: opts.brainApiLimiterAllows ?? true }) },
-    AUTH_MODE: "dev",
-    PIPELINE_TOKEN,
-  } as unknown as Env;
-  return { db, env, renderCache, wpHtml };
 }
 
 export interface ReqOpts {
@@ -278,6 +187,10 @@ export function insertRevision(
   slug: string,
   opts: { userId?: string | null; kind?: string; comment?: string | null; meta?: string | null; createdAt?: number } = {},
 ): number {
+  const createdAt = opts.createdAt ?? Date.now();
+  db.prepare(
+    "INSERT OR IGNORE INTO articles (slug, wikipedia_title, display_title, annotations, version, created_at, updated_at) VALUES (?,?,?,'[]',1,?,?)",
+  ).run(slug, slug, slug, createdAt, createdAt);
   const r = db
     .prepare(
       "INSERT INTO revisions (slug, user_id, annotations, comment, kind, meta, created_at) VALUES (?,?,?,?,?,?,?)",
@@ -289,7 +202,7 @@ export function insertRevision(
       opts.comment ?? null,
       opts.kind ?? "edit",
       opts.meta ?? null,
-      opts.createdAt ?? Date.now(),
+      createdAt,
     );
   return Number(r.lastInsertRowid);
 }

--- a/wiki/test/trust-signals.test.ts
+++ b/wiki/test/trust-signals.test.ts
@@ -1,5 +1,5 @@
 // Trust signals (P2): the N/M human-reviewed header badge + the "?" legend
-// popover on article pages (engine/page.ts, render:v16), and the landing
+// popover on article pages (engine/page.ts, render:v17), and the landing
 // page's "Least recently reviewed" strip (home.ts brainLanding via GET /,
 // page:home:v10). Badge/legend math is unit-tested on renderArticlePage
 // directly; the strip's query (NULLS FIRST ordering, parked-state exclusion,
@@ -113,7 +113,7 @@ describe("legend popover (P2)", () => {
 describe("trust signals through the app", () => {
   blockNetwork();
 
-  it("article pages carry the badge and cache under render:v16", async () => {
+  it("article pages carry the badge and cache under render:v17", async () => {
     const h = setup();
     const res = await get(h.env, `/${SLUG}`);
     expect(res.status).toBe(200);
@@ -122,8 +122,8 @@ describe("trust signals through the app", () => {
     expect(html).toContain(">0/2 human-reviewed<");
     expect(html).toContain('id="wl-legend-btn"');
     const keys = [...h.renderCache.store.keys()];
-    expect(keys.some((k) => k.startsWith("render:v16:"))).toBe(true);
-    expect(keys.some((k) => k.startsWith("render:v15:"))).toBe(false);
+    expect(keys.some((k) => k.startsWith("render:v17:"))).toBe(true);
+    expect(keys.some((k) => k.startsWith("render:v16:"))).toBe(false);
   });
 
   it("landing strip orders NULLS FIRST, excludes parked states, caches under page:home:v10", async () => {

--- a/wiki/tsconfig.json
+++ b/wiki/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmit": true,
     "types": ["node", "@cloudflare/workers-types"]
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "e2e", "playwright.config.ts"]
 }

--- a/wiki/vitest.corpus.config.ts
+++ b/wiki/vitest.corpus.config.ts
@@ -2,9 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts"],
-    exclude: [
-      "test/e2e/**",
+    include: [
       "test/engine.golden.test.ts",
       "test/decl.corpus.test.ts",
       "test/seed.test.ts",


### PR DESCRIPTION
## Summary

- add secret-free PR, main-push, and manual CI with immutable action pins
- make Worker typechecking plus 35 hermetic Vitest files and deterministic Python checks the stable required gate
- add a real-app Playwright Chromium soak covering rendering, axe accessibility, auth return targets, theme persistence, and editor focus/dirty-close behavior
- separate generated corpus checks behind an explicit preflight instead of letting fresh checkouts fail mysteriously
- document local reproduction, failure artifacts, security boundaries, and browser-gate promotion

## Test plan

- `npm run test:ci` under Node 22: 35 files, 792 tests passed
- `npm run test:e2e`: 5/5 Chromium tests passed
- fresh Python 3.12 virtualenv from `requirements-ci.txt`, then `scripts/ci-python.sh`: all five commands passed, offline evaluator 7/7
- `npm run test:corpus`: expected clear preflight failure without generated local corpora
- repository change validator: clean
- whitespace and shell syntax checks: clean
- final general and expert review: no findings

## Rollout

The `required` aggregate currently gates `worker` and `python`. The `browser` job runs on every PR as a visible soak and should be added to the aggregate through a later reviewed workflow change after stable history.

After this PR is green and merged, configure the `main` ruleset to require `CI / required`.