### PR TITLE
test: cover first-login OAuth adapter writes

### DIFF
--- a/wiki/test/auth-adapter.test.ts
+++ b/wiki/test/auth-adapter.test.ts
@@ -161,4 +161,226 @@ describe("Better Auth Drizzle adapter", () => {
       db.close();
     }
   });
+
+  it("persists a first GitHub login through the OAuth callback", async () => {
+    const { env, db } = oauthFixture();
+    try {
+      const signInResponse = await app.request(
+        "https://wikilean.example/api/auth/sign-in/social",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ provider: "github", callbackURL: "/" }),
+        },
+        env,
+      );
+      expect(signInResponse.status).toBe(200);
+
+      const signInBody = (await signInResponse.json()) as { url: string };
+      const state = new URL(signInBody.url).searchParams.get("state");
+      expect(state).toMatch(/^[A-Za-z0-9_-]{32}$/);
+
+      const stateCookie = parseSetCookieHeader(signInResponse.headers.get("set-cookie") ?? "").get(STATE_COOKIE);
+      expect(stateCookie).toBeDefined();
+      const verificationRow = db
+        .prepare("SELECT value FROM verifications WHERE identifier = ?")
+        .get(state) as { value: string } | undefined;
+      expect(verificationRow).toBeDefined();
+      const verification = JSON.parse(verificationRow!.value) as { codeVerifier: string };
+
+      const githubCode = "github-authorization-code";
+      const accessToken = "gho_test_access_token";
+      const refreshToken = "ghr_test_refresh_token";
+      const requestURLs: string[] = [];
+      const blockedFetch = globalThis.fetch;
+      const callbackStartedAt = Math.floor(Date.now() / 1000);
+
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        requestURLs.push(request.url);
+
+        if (request.url === "https://github.com/login/oauth/access_token") {
+          expect(request.method).toBe("POST");
+          expect(request.headers.get("accept")).toBe("application/json");
+          expect(request.headers.get("content-type")).toBe("application/x-www-form-urlencoded");
+          const body = new URLSearchParams(await request.clone().text());
+          expect(Object.fromEntries(body)).toEqual({
+            grant_type: "authorization_code",
+            code: githubCode,
+            code_verifier: verification.codeVerifier,
+            redirect_uri: "https://wikilean.example/api/auth/callback/github",
+            client_id: "Iv1.test",
+            client_secret: "test-secret",
+          });
+          return Response.json({
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            token_type: "bearer",
+            scope: "read:user user:email",
+            expires_in: 3600,
+            refresh_token_expires_in: 7200,
+          });
+        }
+
+        if (request.url === "https://api.github.com/user") {
+          expect(request.method).toBe("GET");
+          expect(request.headers.get("authorization")).toBe(`Bearer ${accessToken}`);
+          expect(request.headers.get("user-agent")).toBe("better-auth");
+          expect(await request.clone().text()).toBe("");
+          return Response.json({
+            id: 1234567,
+            login: "octo-tester",
+            name: "Octo Tester",
+            email: null,
+            avatar_url: "https://avatars.example/octo-tester.png",
+          });
+        }
+
+        if (request.url === "https://api.github.com/user/emails") {
+          expect(request.method).toBe("GET");
+          expect(request.headers.get("authorization")).toBe(`Bearer ${accessToken}`);
+          expect(request.headers.get("user-agent")).toBe("better-auth");
+          expect(await request.clone().text()).toBe("");
+          return Response.json([
+            { email: "secondary@example.org", primary: false, verified: true, visibility: null },
+            { email: "octo@example.org", primary: true, verified: true, visibility: "private" },
+          ]);
+        }
+
+        throw new Error(`unexpected network fetch in OAuth callback test: ${request.method} ${request.url}`);
+      }) as typeof fetch;
+
+      let callbackResponse: Response;
+      try {
+        callbackResponse = await app.request(
+          `https://wikilean.example/api/auth/callback/github?code=${githubCode}&state=${state}`,
+          {
+            headers: {
+              cookie: `${STATE_COOKIE}=${encodeURIComponent(stateCookie!.value)}`,
+              "user-agent": "oauth-callback-test",
+            },
+          },
+          env,
+        );
+      } finally {
+        globalThis.fetch = blockedFetch;
+      }
+      const callbackFinishedAt = Math.floor(Date.now() / 1000);
+
+      expect(callbackResponse.status).toBe(302);
+      expect(callbackResponse.headers.get("location")).toBe("/");
+      expect(requestURLs).toEqual([
+        "https://github.com/login/oauth/access_token",
+        "https://api.github.com/user",
+        "https://api.github.com/user/emails",
+      ]);
+      expect(
+        db.prepare("SELECT COUNT(*) AS count FROM verifications WHERE identifier = ?").get(state),
+      ).toEqual({ count: 0 });
+
+      const user = db
+        .prepare(
+          "SELECT id, name, email, email_verified, image, role, created_at, updated_at FROM users WHERE email = ?",
+        )
+        .get("octo@example.org") as
+        | {
+            id: string;
+            name: string;
+            email: string;
+            email_verified: number;
+            image: string;
+            role: string;
+            created_at: number;
+            updated_at: number;
+          }
+        | undefined;
+      expect(user).toBeDefined();
+      expect(user).toMatchObject({
+        name: "Octo Tester",
+        email: "octo@example.org",
+        email_verified: 1,
+        image: "https://avatars.example/octo-tester.png",
+        role: "user",
+      });
+      expect(user!.id).toMatch(/^[A-Za-z0-9_-]{32}$/);
+      expect(user!.created_at).toBeGreaterThanOrEqual(callbackStartedAt);
+      expect(user!.created_at).toBeLessThanOrEqual(callbackFinishedAt);
+      expect(user!.updated_at).toBe(user!.created_at);
+
+      const account = db
+        .prepare(
+          "SELECT id, user_id, account_id, provider_id, access_token, refresh_token, access_token_expires_at, refresh_token_expires_at, scope, created_at, updated_at FROM accounts WHERE provider_id = ?",
+        )
+        .get("github") as
+        | {
+            id: string;
+            user_id: string;
+            account_id: string;
+            provider_id: string;
+            access_token: string;
+            refresh_token: string;
+            access_token_expires_at: number;
+            refresh_token_expires_at: number;
+            scope: string;
+            created_at: number;
+            updated_at: number;
+          }
+        | undefined;
+      expect(account).toBeDefined();
+      expect(account).toMatchObject({
+        user_id: user!.id,
+        account_id: "1234567",
+        provider_id: "github",
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        scope: "read:user,user:email",
+      });
+      expect(account!.id).toMatch(/^[A-Za-z0-9_-]{32}$/);
+      expect(account!.created_at).toBeGreaterThanOrEqual(callbackStartedAt);
+      expect(account!.created_at).toBeLessThanOrEqual(callbackFinishedAt);
+      expect(account!.updated_at).toBe(account!.created_at);
+      expect(account!.access_token_expires_at).toBeGreaterThanOrEqual(callbackStartedAt + 3600);
+      expect(account!.access_token_expires_at).toBeLessThanOrEqual(callbackFinishedAt + 3600);
+      expect(account!.refresh_token_expires_at).toBeGreaterThanOrEqual(callbackStartedAt + 7200);
+      expect(account!.refresh_token_expires_at).toBeLessThanOrEqual(callbackFinishedAt + 7200);
+
+      const session = db
+        .prepare(
+          "SELECT id, user_id, token, expires_at, user_agent, created_at, updated_at FROM sessions WHERE user_id = ?",
+        )
+        .get(user!.id) as
+        | {
+            id: string;
+            user_id: string;
+            token: string;
+            expires_at: number;
+            user_agent: string;
+            created_at: number;
+            updated_at: number;
+          }
+        | undefined;
+      expect(session).toBeDefined();
+      expect(session).toMatchObject({ user_id: user!.id, user_agent: "oauth-callback-test" });
+      expect(session!.id).toMatch(/^[A-Za-z0-9_-]{32}$/);
+      expect(session!.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+      expect(session!.created_at).toBeGreaterThanOrEqual(callbackStartedAt);
+      expect(session!.created_at).toBeLessThanOrEqual(callbackFinishedAt);
+      expect(session!.updated_at).toBe(session!.created_at);
+      const sevenDays = 7 * 24 * 60 * 60;
+      expect(session!.expires_at).toBeGreaterThanOrEqual(callbackStartedAt + sevenDays);
+      expect(session!.expires_at).toBeLessThanOrEqual(callbackFinishedAt + sevenDays);
+
+      const callbackCookies = parseSetCookieHeader(callbackResponse.headers.get("set-cookie") ?? "");
+      const sessionCookie = callbackCookies.get(SESSION_COOKIE);
+      expect(sessionCookie).toMatchObject({
+        secure: true,
+        httponly: true,
+        samesite: "lax",
+        path: "/",
+      });
+      expect(sessionCookie!.value).toBe(`${session!.token}.${await makeSignature(session!.token, AUTH_SECRET)}`);
+    } finally {
+      db.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- drive Better Auth’s real GitHub OAuth callback from a valid signed state cookie and verification row
- allow only the exact token, profile, and email provider requests; reject all other network access
- verify callback state consumption and persisted `users`, `accounts`, and `sessions` rows
- pin verified-email, default-role, provider linkage, token/scope, and timestamp mappings
- verify the returned secure session cookie matches the persisted session token

## Test plan

- focused `auth-adapter.test.ts`: 5/5 passed, repeated six times
- `npm run test:ci`: 36 files, 797 tests passed
- `npm run test:e2e`: 5/5 Chromium tests passed
- `git diff --check`
- general and expert review: no findings after tightening session expiry bounds

Closes #12.